### PR TITLE
Support any resolvable type in cref attribute in non-body param.

### DIFF
--- a/test/Microsoft.OpenApi.CSharpComment.Reader.Tests/InternalOpenApiDocumentGeneratorTests/Input/AnnotationArrayInParamTags.xml
+++ b/test/Microsoft.OpenApi.CSharpComment.Reader.Tests/InternalOpenApiDocumentGeneratorTests/Input/AnnotationArrayInParamTags.xml
@@ -1,0 +1,349 @@
+﻿<?xml version="1.0"?>
+<doc>
+  <assembly>
+    <name>Microsoft.OpenApi.CSharpComment.Reader.Tests.SampleApis</name>
+  </assembly>
+  <members>
+    <member name="T:Microsoft.OpenApi.CSharpComment.Reader.Tests.SampleApis.RouteConfig">
+      <summary>
+        Responsible for route configuration
+      </summary>
+    </member>
+    <member name="M:Microsoft.OpenApi.CSharpComment.Reader.Tests.SampleApis.RouteConfig.RegisterRoutes(System.Web.Routing.RouteCollection)">
+      <summary>
+        Registers routes
+      </summary>
+      <param name="routes">Route collection</param>
+    </member>
+    <member name="T:Microsoft.OpenApi.CSharpComment.Reader.Tests.SampleApis.WebApiConfig">
+      <summary>
+        Web config.
+      </summary>
+    </member>
+    <member name="M:Microsoft.OpenApi.CSharpComment.Reader.Tests.SampleApis.WebApiConfig.Register(System.Web.Http.HttpConfiguration)">
+      <summary>
+        Register the configuration, services, and routes.
+      </summary>
+      <param name="config">HTTP Configuration</param>
+    </member>
+    <member name="T:Microsoft.OpenApi.CSharpComment.Reader.Tests.SampleApis.Contracts.SampleEnum1">
+      <summary>
+        Sample enum 1
+      </summary>
+    </member>
+    <member name="F:Microsoft.OpenApi.CSharpComment.Reader.Tests.SampleApis.Contracts.SampleEnum1.SampleEnumValue1">
+      <summary>
+        Sample enum value 1
+      </summary>
+    </member>
+    <member name="F:Microsoft.OpenApi.CSharpComment.Reader.Tests.SampleApis.Contracts.SampleEnum1.SampleEnumValue2">
+      <summary>
+        Sample enum value 2
+      </summary>
+    </member>
+    <member name="T:Microsoft.OpenApi.CSharpComment.Reader.Tests.SampleApis.Contracts.SampleObject1">
+      <summary>
+        Sample contract for object 1
+      </summary>
+    </member>
+    <member name="P:Microsoft.OpenApi.CSharpComment.Reader.Tests.SampleApis.Contracts.SampleObject1.SamplePropertyBool">
+      <summary>
+        Gets or sets the sample property bool
+      </summary>
+    </member>
+    <member name="P:Microsoft.OpenApi.CSharpComment.Reader.Tests.SampleApis.Contracts.SampleObject1.SamplePropertyInt">
+      <summary>
+        Gets or sets the sample property int
+      </summary>
+    </member>
+    <member name="P:Microsoft.OpenApi.CSharpComment.Reader.Tests.SampleApis.Contracts.SampleObject1.SamplePropertyString1">
+      <summary>
+        Gets or sets the sample property string 1
+      </summary>
+    </member>
+    <member name="P:Microsoft.OpenApi.CSharpComment.Reader.Tests.SampleApis.Contracts.SampleObject1.SamplePropertyString2">
+      <summary>
+        Gets or sets the sample property string 2
+      </summary>
+    </member>
+    <member name="P:Microsoft.OpenApi.CSharpComment.Reader.Tests.SampleApis.Contracts.SampleObject1.SamplePropertyString3">
+      <summary>
+        Gets or sets the sample property string 3
+      </summary>
+    </member>
+    <member name="P:Microsoft.OpenApi.CSharpComment.Reader.Tests.SampleApis.Contracts.SampleObject1.SamplePropertyString4">
+      <summary>
+        Gets or sets the sample property string 4
+      </summary>
+    </member>
+    <member name="P:Microsoft.OpenApi.CSharpComment.Reader.Tests.SampleApis.Contracts.SampleObject1.SamplePropertyEnum">
+      <summary>
+        Gets or sets the sample property enum
+      </summary>
+    </member>
+    <member name="T:Microsoft.OpenApi.CSharpComment.Reader.Tests.SampleApis.Contracts.SampleObject3">
+      <summary>
+        Sample contract for object 3
+      </summary>
+    </member>
+    <member name="P:Microsoft.OpenApi.CSharpComment.Reader.Tests.SampleApis.Contracts.SampleObject3.SamplePropertyObject">
+      <summary>
+        Gets or sets sample property object
+      </summary>
+    </member>
+    <member name="P:Microsoft.OpenApi.CSharpComment.Reader.Tests.SampleApis.Contracts.SampleObject3.SamplePropertyObjectList">
+      <summary>
+        Gets the sample property object list
+      </summary>
+    </member>
+    <member name="T:Microsoft.OpenApi.CSharpComment.Reader.Tests.SampleApis.Contracts.SampleObject2">
+      <summary>
+        Sample contract for object 2
+      </summary>
+    </member>
+    <member name="P:Microsoft.OpenApi.CSharpComment.Reader.Tests.SampleApis.Contracts.SampleObject2.SamplePropertyEnum">
+      <summary>
+        Gets or sets the sample property enum
+      </summary>
+    </member>
+    <member name="P:Microsoft.OpenApi.CSharpComment.Reader.Tests.SampleApis.Contracts.SampleObject2.SamplePropertyInt">
+      <summary>
+        Gets or sets the sample property string 1
+      </summary>
+    </member>
+    <member name="P:Microsoft.OpenApi.CSharpComment.Reader.Tests.SampleApis.Contracts.SampleObject2.SamplePropertyObjectDictionary">
+      <summary>
+        Gets the sample property object dictionary
+      </summary>
+    </member>
+    <member name="P:Microsoft.OpenApi.CSharpComment.Reader.Tests.SampleApis.Contracts.SampleObject2.SamplePropertyObjectList">
+      <summary>
+        Gets the sample property object list
+      </summary>
+    </member>
+    <member name="P:Microsoft.OpenApi.CSharpComment.Reader.Tests.SampleApis.Contracts.SampleObject2.SamplePropertyString1">
+      <summary>
+        Gets or sets the sample property string 1
+      </summary>
+    </member>
+    <member name="T:Microsoft.OpenApi.CSharpComment.Reader.Tests.SampleApis.Contracts.ISampleObject4`2">
+      <summary>
+        Interface Sample Object 4
+      </summary>
+    </member>
+    <member name="P:Microsoft.OpenApi.CSharpComment.Reader.Tests.SampleApis.Contracts.ISampleObject4`2.SamplePropertyTypeT1">
+      <summary>
+        Sample Property of Type T1
+      </summary>
+    </member>
+    <member name="P:Microsoft.OpenApi.CSharpComment.Reader.Tests.SampleApis.Contracts.ISampleObject4`2.SamplePropertyTypeT2">
+      <summary>
+        Sample Property of Type T2
+      </summary>
+    </member>
+    <member name="T:Microsoft.OpenApi.CSharpComment.Reader.Tests.SampleApis.Controllers.SampleControllerV1">
+      <summary>
+        Define V1 operations.
+      </summary>
+    </member>
+    <member name="M:Microsoft.OpenApi.CSharpComment.Reader.Tests.SampleApis.Controllers.SampleControllerV1.SampleGet1(System.String,System.Boolean)">
+      <summary>
+        Sample Get 1
+      </summary>
+      <group>Sample V1</group>
+      <verb>GET</verb>
+      <url>http://localhost:9000/V1/samples/{id}?queryBool={queryBool}</url>
+      <param name="sampleHeaderParam1" cref="T:System.Single" in="header">Header param 1</param>
+      <param name="sampleHeaderParam2" cref="T:System.String" in="header">Header param 2</param>
+      <param name="sampleHeaderParam3" cref="T:System.String" in="header">Header param 3</param>
+      <param name="id" cref="T:System.String" in="path">The object id</param>
+      <!-- Array type in param tag for a query param -->
+      <param name="queryBool" required="true" cref="T:System.String[]" in="query">Sample query boolean</param>
+      <!-- ///////////////////////////////////////// -->
+      <response code="200">
+        <see cref="T:Microsoft.OpenApi.CSharpComment.Reader.Tests.SampleApis.Contracts.SampleObject1"/>Sample object retrieved
+      </response>
+      <response code="400">
+        <see cref="T:System.String"/>Bad request
+      </response>
+      <swagger>Group1</swagger>
+      <swagger>Group2</swagger>
+      <returns>The sample object 1</returns>
+    </member>
+    <member name="M:Microsoft.OpenApi.CSharpComment.Reader.Tests.SampleApis.Controllers.SampleControllerV1.SampleGet2">
+      <summary>
+        Sample Get 2
+      </summary>
+      <group>Sample V1</group>
+      <verb>GET</verb>
+      <url>http://localhost:9000/V1/samples</url>
+      <param name="sampleHeaderParam1" cref="T:System.Single" in="header">Header param 1</param>
+      <param name="sampleHeaderParam2" cref="T:System.String" in="header">Header param 2</param>
+      <param name="sampleHeaderParam3" cref="T:System.String" in="header">Header param 3</param>
+      <response code="200">
+        <see cref="T:Microsoft.OpenApi.CSharpComment.Reader.Tests.SampleApis.Contracts.SampleObject3"/>Paged Entity contract
+      </response>
+      <response code="400">
+        <see cref="T:System.String"/>Bad request
+      </response>
+      <returns>The sample object 3</returns>
+    </member>
+    <member name="M:Microsoft.OpenApi.CSharpComment.Reader.Tests.SampleApis.Controllers.SampleControllerV1.SamplePost(Microsoft.OpenApi.CSharpComment.Reader.Tests.SampleApis.Contracts.SampleObject3)">
+      <summary>
+        Sample Post
+      </summary>
+      <group>Sample V1</group>
+      <verb>POST</verb>
+      <url>http://localhost:9000/V1/samples</url>
+      <param name="sampleHeaderParam1" cref="T:System.Single" in="header">Header param 1</param>
+      <param name="sampleHeaderParam2" cref="T:System.String" in="header">Header param 2</param>
+      <param name="sampleHeaderParam3" cref="T:System.String" in="header">Header param 3</param>
+      <param name="sampleObject" in="body">
+        <see cref="T:Microsoft.OpenApi.CSharpComment.Reader.Tests.SampleApis.Contracts.SampleObject3"/>Sample object
+      </param>
+      <response code="200">
+        <see cref="T:Microsoft.OpenApi.CSharpComment.Reader.Tests.SampleApis.Contracts.SampleObject3"/>Sample object posted
+      </response>
+      <response code="400">
+        <see cref="T:System.String"/>Bad request
+      </response>
+    </member>
+    <member name="M:Microsoft.OpenApi.CSharpComment.Reader.Tests.SampleApis.Controllers.SampleControllerV1.SamplePut(System.String,Microsoft.OpenApi.CSharpComment.Reader.Tests.SampleApis.Contracts.SampleObject1)">
+      <summary>
+        Sample put
+      </summary>
+      <group>Sample V1</group>
+      <verb>PUT</verb>
+      <url>http://localhost:9000/V1/samples/{id}</url>
+      <param name="sampleHeaderParam1" cref="T:System.Single" in="header">Header param 1</param>
+      <param name="sampleHeaderParam2" cref="T:System.String" in="header">Header param 2</param>
+      <param name="sampleHeaderParam3" cref="T:System.String" in="header">Header param 3</param>
+      <param name="id" cref="T:System.String" in="path">The object id</param>
+      <param name="sampleObject" in="body">
+        <see cref="T:Microsoft.OpenApi.CSharpComment.Reader.Tests.SampleApis.Contracts.SampleObject1"/>Sample object
+      </param>
+      <response code="200">
+        <see cref="T:Microsoft.OpenApi.CSharpComment.Reader.Tests.SampleApis.Contracts.SampleObject1"/>The sample object updated
+      </response>
+      <response code="400">
+        <see cref="T:System.String"/>Bad request
+      </response>
+      <returns>The sample object 1</returns>
+    </member>
+    <member name="T:Microsoft.OpenApi.CSharpComment.Reader.Tests.SampleApis.Controllers.SampleControllerV3">
+      <summary>
+        Defines V3 operations.
+      </summary>
+    </member>
+    <member name="M:Microsoft.OpenApi.CSharpComment.Reader.Tests.SampleApis.Controllers.SampleControllerV3.SampleGet1">
+      <summary>
+        Sample get 1
+      </summary>
+      <group>Sample V3</group>
+      <verb>GET</verb>
+      <url>http://localhost:9000/V3/samples/</url>
+      <param name="sampleHeaderParam1" cref="T:System.Single" in="header">Header param 1</param>
+      <param name="sampleHeaderParam2" cref="T:System.String" in="header">Header param 2</param>
+      <param name="sampleHeaderParam3" cref="T:System.String" in="header">Header param 3</param>
+      <response code="200">
+        <see cref="T:System.Collections.Generic.List`1"/>
+        where T is <see cref="T:Microsoft.OpenApi.CSharpComment.Reader.Tests.SampleApis.Contracts.ISampleObject4`2"/>
+        where T1 is <see cref="T:Microsoft.OpenApi.CSharpComment.Reader.Tests.SampleApis.Contracts.SampleObject1"/>
+        where T2 is <see cref="T:Microsoft.OpenApi.CSharpComment.Reader.Tests.SampleApis.Contracts.SampleObject2"/>
+      </response>
+      <response code="400">
+        <see cref="T:System.String"/>Bad request
+      </response>
+    </member>
+    <member name="M:Microsoft.OpenApi.CSharpComment.Reader.Tests.SampleApis.Controllers.SampleControllerV3.SampleGet2(System.String,System.String)">
+      <summary>
+        Sample get 2
+      </summary>
+      <group>Sample V3</group>
+      <verb>GET</verb>
+      <url>http://localhost:9000/V3/samples/{id}?queryString={queryString}</url>
+      <param name="sampleHeaderParam1" cref="T:System.Single" in="header">Header param 1</param>
+      <param name="sampleHeaderParam2" cref="T:System.String" in="header">Header param 2</param>
+      <param name="sampleHeaderParam3" cref="T:System.String" in="header">Header param 3</param>
+      <param name="id" cref="T:System.String" in="path">The object id</param>
+      <param name="queryString" cref="T:System.String" in="query">The sample query string</param>
+      <response code="200">
+        <see cref="T:Microsoft.OpenApi.CSharpComment.Reader.Tests.SampleApis.Contracts.ISampleObject4`2"/>
+        where T1 is <see cref="T:Microsoft.OpenApi.CSharpComment.Reader.Tests.SampleApis.Contracts.SampleObject1"/>
+        where T2 is <see cref="T:Microsoft.OpenApi.CSharpComment.Reader.Tests.SampleApis.Contracts.SampleObject2"/>
+      </response>
+      <response code="400">
+        <see cref="T:System.String"/>Bad request
+      </response>
+    </member>
+    <member name="T:Microsoft.OpenApi.CSharpComment.Reader.Tests.SampleApis.Controllers.SampleControllerV2">
+      <summary>
+        Defines V2 operations.
+      </summary>
+    </member>
+    <member name="M:Microsoft.OpenApi.CSharpComment.Reader.Tests.SampleApis.Controllers.SampleControllerV2.DeleteEntity(System.String)">
+      <summary>
+        Sample delete
+      </summary>
+      <group>Sample V2</group>
+      <verb>DELETE</verb>
+      <url>http://localhost:9000/V2/samples/{id}</url>
+      <param name="sampleHeaderParam1" cref="T:System.Single" in="header">Header param 1</param>
+      <param name="sampleHeaderParam2" cref="T:System.String" in="header">Header param 2</param>
+      <param name="sampleHeaderParam3" cref="T:System.String" in="header">Header param 3</param>
+      <param name="id" cref="T:System.String" in="path">The object id</param>
+      <response code="200">
+        <see cref="T:Microsoft.OpenApi.CSharpComment.Reader.Tests.SampleApis.Contracts.SampleObject1"/>Sample object deleted
+      </response>
+      <response code="400">
+        <see cref="T:System.String"/>Bad request
+      </response>
+    </member>
+    <member name="M:Microsoft.OpenApi.CSharpComment.Reader.Tests.SampleApis.Controllers.SampleControllerV2.SampleGet1">
+      <summary>
+        Sample get 1
+      </summary>
+      <group>Sample V2</group>
+      <verb>GET</verb>
+      <url>http://localhost:9000/V2/samples/</url>
+      <param name="sampleHeaderParam1" cref="T:System.Single" in="header">Header param 1</param>
+      <param name="sampleHeaderParam2" cref="T:System.String" in="header">Header param 2</param>
+      <param name="sampleHeaderParam3" cref="T:System.String" in="header">Header param 3</param>
+      <response code="200">
+        <see cref="T:System.Collections.Generic.List`1"/>where T is <see cref="T:Microsoft.OpenApi.CSharpComment.Reader.Tests.SampleApis.Contracts.SampleObject2"/>List of sample objects
+      </response>
+      <response code="400">
+        <see cref="T:System.String"/>Bad request
+      </response>
+    </member>
+    <member name="M:Microsoft.OpenApi.CSharpComment.Reader.Tests.SampleApis.Controllers.SampleControllerV2.SampleGet2(System.String,System.String)">
+      <summary>
+        Sample get 2
+      </summary>
+      <group>Sample V2</group>
+      <verb>GET</verb>
+      <url>http://localhost:9000/V2/samples/{id}?queryString={queryString}</url>
+      <param name="sampleHeaderParam1" cref="T:System.Single" in="header">Header param 1</param>
+      <param name="sampleHeaderParam2" cref="T:System.String" in="header">Header param 2</param>
+      <param name="sampleHeaderParam3" cref="T:System.String" in="header">Header param 3</param>
+      <param name="id" cref="T:System.String" in="path">The object id</param>
+      <param name="queryString" cref="T:System.String" in="query">The sample query string</param>
+      <response code="200">
+        <see cref="T:Microsoft.OpenApi.CSharpComment.Reader.Tests.SampleApis.Contracts.SampleObject2"/>Sample object retrieved
+      </response>
+      <response code="400">
+        <see cref="T:System.String"/>Bad request
+      </response>
+    </member>
+    <member name="T:Microsoft.OpenApi.CSharpComment.Reader.Tests.SampleApis.WebApiApplication">
+      <summary>
+        Web API Application.
+      </summary>
+    </member>
+    <member name="M:Microsoft.OpenApi.CSharpComment.Reader.Tests.SampleApis.WebApiApplication.Application_Start">
+      <summary>
+        Start application.
+      </summary>
+    </member>
+  </members>
+</doc>

--- a/test/Microsoft.OpenApi.CSharpComment.Reader.Tests/InternalOpenApiDocumentGeneratorTests/InternalOpenApiDocumentGeneratorTest.cs
+++ b/test/Microsoft.OpenApi.CSharpComment.Reader.Tests/InternalOpenApiDocumentGeneratorTests/InternalOpenApiDocumentGeneratorTest.cs
@@ -1,6 +1,6 @@
 ﻿// ------------------------------------------------------------
 //  Copyright (c) Microsoft Corporation.  All rights reserved.
-//  Licensed under the MIT License (MIT). See License.txt in the repo root for license information.
+//  Licensed under the MIT License (MIT). See LICENSE in the repo root for license information.
 // ------------------------------------------------------------
 
 using System.Collections.Generic;
@@ -394,6 +394,23 @@ namespace Microsoft.OpenApi.CSharpComment.Reader.Tests.InternalOpenApiDocumentGe
                 Path.Combine(
                     OutputDirectory,
                     "Annotation.Json")
+            };
+
+            // Valid XML document with array type in param tags.
+            yield return new object[]
+            {
+                "Array Type in Param Tags",
+                Path.Combine(InputDirectory, "AnnotationArrayInParamTags.xml"),
+                new List<string>
+                {
+                    Path.Combine(
+                        InputDirectory,
+                        "Microsoft.OpenApi.CSharpComment.Reader.Tests.SampleApis.dll")
+                },
+                9,
+                Path.Combine(
+                    OutputDirectory,
+                    "AnnotationArrayInParamTags.Json")
             };
         }
 

--- a/test/Microsoft.OpenApi.CSharpComment.Reader.Tests/InternalOpenApiDocumentGeneratorTests/Output/AnnotationArrayInParamTags.Json
+++ b/test/Microsoft.OpenApi.CSharpComment.Reader.Tests/InternalOpenApiDocumentGeneratorTests/Output/AnnotationArrayInParamTags.Json
@@ -1,0 +1,762 @@
+{
+    "components": {
+        "schemas": {
+            "Microsoft.OpenApi.CSharpComment.Reader.Tests.SampleApis.Contracts.SampleObject1": {
+                "properties": {
+                    "samplePropertyBool": {
+                        "description": "Gets or sets the sample property bool",
+                        "readOnly": false,
+                        "type": "boolean"
+                    },
+                    "samplePropertyStringInt": {
+                        "description": "Gets or sets the sample property int",
+                        "format": "int32",
+                        "readOnly": false,
+                        "type": "integer"
+                    },
+                    "samplePropertyString1": {
+                        "description": "Gets or sets the sample property string 1",
+                        "readOnly": false,
+                        "type": "string"
+                    },
+                    "samplePropertyString2": {
+                        "description": "Gets or sets the sample property string 2",
+                        "readOnly": false,
+                        "type": "string"
+                    },
+                    "samplePropertyString3": {
+                        "description": "Gets or sets the sample property string 3",
+                        "readOnly": false,
+                        "type": "string"
+                    },
+                    "samplePropertyString4": {
+                        "description": "Gets or sets the sample property string 4",
+                        "readOnly": false,
+                        "type": "string"
+                    },
+                    "samplePropertyEnum": {
+                        "description": "Gets or sets the sample property enum",
+                        "enum": [
+                            "SampleEnumValue1",
+                            "SampleEnumValue2"
+                        ],
+                        "readOnly": false,
+                        "type": "string"
+                    }
+                },
+                "required": [
+                    "samplePropertyString3",
+                    "samplePropertyString4",
+                    "samplePropertyEnum"
+                ],
+                "type": "object"
+            },
+            "Microsoft.OpenApi.CSharpComment.Reader.Tests.SampleApis.Contracts.SampleObject3": {
+                "properties": {
+                    "samplePropertyObject": {
+                        "description": "Gets or sets sample property object",
+                        "readOnly": false,
+                        "$ref":
+                            "#/components/schemas/Microsoft.OpenApi.CSharpComment.Reader.Tests.SampleApis.Contracts.SampleObject2"
+                    },
+                    "samplePropertyObjectList": {
+                        "description": "Gets the sample property object list",
+                        "items": {
+                            "$ref":
+                                "#/components/schemas/Microsoft.OpenApi.CSharpComment.Reader.Tests.SampleApis.Contracts.SampleObject1"
+                        },
+                        "readOnly": true,
+                        "type": "array"
+                    }
+                },
+                "required": ["samplePropertyObject"],
+                "type": "object"
+            },
+            "Microsoft.OpenApi.CSharpComment.Reader.Tests.SampleApis.Contracts.SampleObject2": {
+                "properties": {
+                    "samplePropertyEnum": {
+                        "description": "Gets or sets the sample property enum",
+                        "enum": [
+                            "SampleEnumValue1",
+                            "SampleEnumValue2"
+                        ],
+                        "readOnly": false,
+                        "type": "string"
+                    },
+                    "samplePropertyInt": {
+                        "description": "Gets or sets the sample property string 1",
+                        "readOnly": false,
+                        "type": "string"
+                    },
+                    "samplePropertyObjectDictionary": {
+                        "additionalProperties": {
+                            "$ref":
+                                "#/components/schemas/Microsoft.OpenApi.CSharpComment.Reader.Tests.SampleApis.Contracts.SampleObject1"
+                        },
+                        "description": "Gets the sample property object dictionary",
+                        "readOnly": true,
+                        "type": "object"
+                    },
+                    "samplePropertyObjectList": {
+                        "description": "Gets the sample property object list",
+                        "items": {
+                            "$ref":
+                                "#/components/schemas/Microsoft.OpenApi.CSharpComment.Reader.Tests.SampleApis.Contracts.SampleObject1"
+                        },
+                        "readOnly": true,
+                        "type": "array"
+                    },
+                    "samplePropertyString1": {
+                        "description": "Gets or sets the sample property string 1",
+                        "readOnly": false,
+                        "type": "string"
+                    }
+                },
+                "required": [
+                    "samplePropertyInt",
+                    "samplePropertyObjectDictionary",
+                    "samplePropertyObjectList"
+                ],
+                "type": "object"
+            },
+            "Microsoft.OpenApi.CSharpComment.Reader.Tests.SampleApis.Contracts.ISampleObject4_Microsoft.OpenApi.CSharpComment.Reader.Tests.SampleApis.Contracts.SampleObject1-Microsoft.OpenApi.CSharpComment.Reader.Tests.SampleApis.Contracts.SampleObject2_":
+            {
+                "properties": {
+                    "samplePropertyTypeT1": {
+                        "description": "Sample Property of Type T1",
+                        "readOnly": false,
+                        "$ref":
+                            "#/components/schemas/Microsoft.OpenApi.CSharpComment.Reader.Tests.SampleApis.Contracts.SampleObject1"
+                    },
+                    "samplePropertyTypeT2": {
+                        "description": "Sample Property of Type T2",
+                        "readOnly": false,
+                        "$ref":
+                            "#/components/schemas/Microsoft.OpenApi.CSharpComment.Reader.Tests.SampleApis.Contracts.SampleObject2"
+                    }
+                },
+                "required": [
+                    "samplePropertyTypeT1",
+                    "samplePropertyTypeT2"
+                ],
+                "type": "object"
+            }
+        }
+    },
+    "info": {
+        "title": "Microsoft.OpenApi.CSharpComment.Reader.Tests.SampleApis",
+        "version": "1.0.0"
+    },
+    "openapi": "3.0.0",
+    "paths": {
+        "/V1/samples/{id}": {
+            "get": {
+                "operationId": "getV1SamplesById",
+                "parameters": [
+                    {
+                        "in": "header",
+                        "required": false,
+                        "name": "sampleHeaderParam1",
+                        "schema": {
+                            "format": "float",
+                            "type": "number"
+                        }
+                    },
+                    {
+                        "in": "header",
+                        "required": false,
+                        "name": "sampleHeaderParam2",
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    {
+                        "in": "header",
+                        "required": false,
+                        "name": "sampleHeaderParam3",
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    {
+                        "in": "path",
+                        "required": false,
+                        "name": "id",
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    {
+                        "in": "query",
+                        "required": true,
+                        "name": "queryBool",
+                        "schema": {
+                            "items": {
+                                "type": "string"
+                            },
+                            "type": "array"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref":
+                                        "#/components/schemas/Microsoft.OpenApi.CSharpComment.Reader.Tests.SampleApis.Contracts.SampleObject1"
+                                }
+                            }
+                        },
+                        "description": "Sample object retrieved"
+                    },
+                    "400": {
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "string"
+                                }
+                            }
+                        },
+                        "description": "Bad request"
+                    }
+                },
+                "summary": "Sample Get 1",
+                "tags": ["Sample V1"]
+            },
+            "put": {
+                "operationId": "putV1SamplesById",
+                "parameters": [
+                    {
+                        "in": "header",
+                        "required": false,
+                        "name": "sampleHeaderParam1",
+                        "schema": {
+                            "format": "float",
+                            "type": "number"
+                        }
+                    },
+                    {
+                        "in": "header",
+                        "required": false,
+                        "name": "sampleHeaderParam2",
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    {
+                        "in": "header",
+                        "required": false,
+                        "name": "sampleHeaderParam3",
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    {
+                        "in": "path",
+                        "required": false,
+                        "name": "id",
+                        "schema": {
+                            "type": "string"
+                        }
+                    }
+                ],
+                "requestBody": {
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "$ref":
+                                    "#/components/schemas/Microsoft.OpenApi.CSharpComment.Reader.Tests.SampleApis.Contracts.SampleObject1"
+                            }
+                        }
+                    },
+                    "description": "Sample object",
+                    "required": true
+                },
+                "responses": {
+                    "200": {
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref":
+                                        "#/components/schemas/Microsoft.OpenApi.CSharpComment.Reader.Tests.SampleApis.Contracts.SampleObject1"
+                                }
+                            }
+                        },
+                        "description": "The sample object updated"
+                    },
+                    "400": {
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "string"
+                                }
+                            }
+                        },
+                        "description": "Bad request"
+                    }
+                },
+                "summary": "Sample put",
+                "tags": ["Sample V1"]
+            }
+        },
+        "/V1/samples": {
+            "get": {
+                "operationId": "getV1Samples",
+                "parameters": [
+                    {
+                        "in": "header",
+                        "required": false,
+                        "name": "sampleHeaderParam1",
+                        "schema": {
+                            "format": "float",
+                            "type": "number"
+                        }
+                    },
+                    {
+                        "in": "header",
+                        "required": false,
+                        "name": "sampleHeaderParam2",
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    {
+                        "in": "header",
+                        "required": false,
+                        "name": "sampleHeaderParam3",
+                        "schema": {
+                            "type": "string"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref":
+                                        "#/components/schemas/Microsoft.OpenApi.CSharpComment.Reader.Tests.SampleApis.Contracts.SampleObject3"
+                                }
+                            }
+                        },
+                        "description": "Paged Entity contract"
+                    },
+                    "400": {
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "string"
+                                }
+                            }
+                        },
+                        "description": "Bad request"
+                    }
+                },
+                "summary": "Sample Get 2",
+                "tags": ["Sample V1"]
+            },
+            "post": {
+                "operationId": "postV1Samples",
+                "parameters": [
+                    {
+                        "in": "header",
+                        "required": false,
+                        "name": "sampleHeaderParam1",
+                        "schema": {
+                            "format": "float",
+                            "type": "number"
+                        }
+                    },
+                    {
+                        "in": "header",
+                        "required": false,
+                        "name": "sampleHeaderParam2",
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    {
+                        "in": "header",
+                        "required": false,
+                        "name": "sampleHeaderParam3",
+                        "schema": {
+                            "type": "string"
+                        }
+                    }
+                ],
+                "requestBody": {
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "$ref":
+                                    "#/components/schemas/Microsoft.OpenApi.CSharpComment.Reader.Tests.SampleApis.Contracts.SampleObject3"
+                            }
+                        }
+                    },
+                    "description": "Sample object",
+                    "required": true
+                },
+                "responses": {
+                    "200": {
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref":
+                                        "#/components/schemas/Microsoft.OpenApi.CSharpComment.Reader.Tests.SampleApis.Contracts.SampleObject3"
+                                }
+                            }
+                        },
+                        "description": "Sample object posted"
+                    },
+                    "400": {
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "string"
+                                }
+                            }
+                        },
+                        "description": "Bad request"
+                    }
+                },
+                "summary": "Sample Post",
+                "tags": ["Sample V1"]
+            }
+        },
+        "/V3/samples/": {
+            "get": {
+                "operationId": "getV3Samples",
+                "parameters": [
+                    {
+                        "in": "header",
+                        "required": false,
+                        "name": "sampleHeaderParam1",
+                        "schema": {
+                            "format": "float",
+                            "type": "number"
+                        }
+                    },
+                    {
+                        "in": "header",
+                        "required": false,
+                        "name": "sampleHeaderParam2",
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    {
+                        "in": "header",
+                        "required": false,
+                        "name": "sampleHeaderParam3",
+                        "schema": {
+                            "type": "string"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "items": {
+                                        "$ref":
+                                            "#/components/schemas/Microsoft.OpenApi.CSharpComment.Reader.Tests.SampleApis.Contracts.ISampleObject4_Microsoft.OpenApi.CSharpComment.Reader.Tests.SampleApis.Contracts.SampleObject1-Microsoft.OpenApi.CSharpComment.Reader.Tests.SampleApis.Contracts.SampleObject2_"
+                                    },
+                                    "type": "array"
+                                }
+                            }
+                        },
+                        "description": ""
+                    },
+                    "400": {
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "string"
+                                }
+                            }
+                        },
+                        "description": "Bad request"
+                    }
+                },
+                "summary": "Sample get 1",
+                "tags": ["Sample V3"]
+            }
+        },
+        "/V3/samples/{id}": {
+            "get": {
+                "operationId": "getV3SamplesById",
+                "parameters": [
+                    {
+                        "in": "header",
+                        "required": false,
+                        "name": "sampleHeaderParam1",
+                        "schema": {
+                            "format": "float",
+                            "type": "number"
+                        }
+                    },
+                    {
+                        "in": "header",
+                        "required": false,
+                        "name": "sampleHeaderParam2",
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    {
+                        "in": "header",
+                        "required": false,
+                        "name": "sampleHeaderParam3",
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    {
+                        "in": "path",
+                        "required": false,
+                        "name": "id",
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    {
+                        "in": "query",
+                        "required": false,
+                        "name": "queryString",
+                        "schema": {
+                            "type": "string"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref":
+                                        "#/components/schemas/Microsoft.OpenApi.CSharpComment.Reader.Tests.SampleApis.Contracts.ISampleObject4_Microsoft.OpenApi.CSharpComment.Reader.Tests.SampleApis.Contracts.SampleObject1-Microsoft.OpenApi.CSharpComment.Reader.Tests.SampleApis.Contracts.SampleObject2_"
+                                }
+                            }
+                        },
+                        "description": ""
+                    },
+                    "400": {
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "string"
+                                }
+                            }
+                        },
+                        "description": "Bad request"
+                    }
+                },
+                "summary": "Sample get 2",
+                "tags": ["Sample V3"]
+            }
+        },
+        "/V2/samples/{id}": {
+            "delete": {
+                "operationId": "deleteV2SamplesById",
+                "parameters": [
+                    {
+                        "in": "header",
+                        "required": false,
+                        "name": "sampleHeaderParam1",
+                        "schema": {
+                            "format": "float",
+                            "type": "number"
+                        }
+                    },
+                    {
+                        "in": "header",
+                        "required": false,
+                        "name": "sampleHeaderParam2",
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    {
+                        "in": "header",
+                        "required": false,
+                        "name": "sampleHeaderParam3",
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    {
+                        "in": "path",
+                        "required": false,
+                        "name": "id",
+                        "schema": {
+                            "type": "string"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref":
+                                        "#/components/schemas/Microsoft.OpenApi.CSharpComment.Reader.Tests.SampleApis.Contracts.SampleObject1"
+                                }
+                            }
+                        },
+                        "description": "Sample object deleted"
+                    },
+                    "400": {
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "string"
+                                }
+                            }
+                        },
+                        "description": "Bad request"
+                    }
+                },
+                "summary": "Sample delete",
+                "tags": ["Sample V2"]
+            },
+            "get": {
+                "operationId": "getV2SamplesById",
+                "parameters": [
+                    {
+                        "in": "header",
+                        "required": false,
+                        "name": "sampleHeaderParam1",
+                        "schema": {
+                            "format": "float",
+                            "type": "number"
+                        }
+                    },
+                    {
+                        "in": "header",
+                        "required": false,
+                        "name": "sampleHeaderParam2",
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    {
+                        "in": "header",
+                        "required": false,
+                        "name": "sampleHeaderParam3",
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    {
+                        "in": "path",
+                        "required": false,
+                        "name": "id",
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    {
+                        "in": "query",
+                        "required": false,
+                        "name": "queryString",
+                        "schema": {
+                            "type": "string"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref":
+                                        "#/components/schemas/Microsoft.OpenApi.CSharpComment.Reader.Tests.SampleApis.Contracts.SampleObject2"
+                                }
+                            }
+                        },
+                        "description": "Sample object retrieved"
+                    },
+                    "400": {
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "string"
+                                }
+                            }
+                        },
+                        "description": "Bad request"
+                    }
+                },
+                "summary": "Sample get 2",
+                "tags": ["Sample V2"]
+            }
+        },
+        "/V2/samples/": {
+            "get": {
+                "operationId": "getV2Samples",
+                "parameters": [
+                    {
+                        "in": "header",
+                        "required": false,
+                        "name": "sampleHeaderParam1",
+                        "schema": {
+                            "format": "float",
+                            "type": "number"
+                        }
+                    },
+                    {
+                        "in": "header",
+                        "required": false,
+                        "name": "sampleHeaderParam2",
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    {
+                        "in": "header",
+                        "required": false,
+                        "name": "sampleHeaderParam3",
+                        "schema": {
+                            "type": "string"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "items": {
+                                        "$ref":
+                                            "#/components/schemas/Microsoft.OpenApi.CSharpComment.Reader.Tests.SampleApis.Contracts.SampleObject2"
+                                    },
+                                    "type": "array"
+                                }
+                            }
+                        },
+                        "description": "List of sample objects"
+                    },
+                    "400": {
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "string"
+                                }
+                            }
+                        },
+                        "description": "Bad request"
+                    }
+                },
+                "summary": "Sample get 1",
+                "tags": ["Sample V2"]
+            }
+        }
+    },
+    "servers": [
+        {
+            "url": "http://localhost:9000"
+        }
+    ]
+}

--- a/test/Microsoft.OpenApi.CSharpComment.Reader.Tests/Microsoft.OpenApi.CSharpComment.Reader.Tests.csproj
+++ b/test/Microsoft.OpenApi.CSharpComment.Reader.Tests/Microsoft.OpenApi.CSharpComment.Reader.Tests.csproj
@@ -110,6 +110,9 @@
     <Content Include="DocumentVariantTests\Input\Microsoft.OpenApi.CSharpComment.Reader.Tests.SampleApis.dll">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </Content>
+    <Content Include="InternalOpenApiDocumentGeneratorTests\Input\AnnotationArrayInParamTags.xml">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </Content>
     <Content Include="InternalOpenApiDocumentGeneratorTests\Input\AnnotationAlternativeParamTags.xml">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </Content>
@@ -341,6 +344,9 @@
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </Content>
     <Content Include="InternalOpenApiDocumentGeneratorTests\Output\AnnotationOptionalPathParametersBranching.Json">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </Content>
+    <Content Include="InternalOpenApiDocumentGeneratorTests\Output\AnnotationArrayInParamTags.Json">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </Content>
     <None Include="packages.config" />


### PR DESCRIPTION
Support any resolvable type in `cref` attribute in `param` tag.

Before the change: Only primitive type is allowed in `cref`, and `MapToOpenApiDataTypeFormatPair` is called from `ParamToParameterFilter` directly.

After the change: Type in `cref` for non-body param (path, query, header) is now resolved by leveraging the `SchemaReferenceRegistry`. This is consistent with how the type in body param or response is resolved.