### PR TITLE
Removing localhost from the sample API to promote best practices in annotations.

### DIFF
--- a/test/Microsoft.OpenApi.CSharpAnnotations.DocumentGeneration.Tests.SampleApis/Controllers/SampleControllerV1.cs
+++ b/test/Microsoft.OpenApi.CSharpAnnotations.DocumentGeneration.Tests.SampleApis/Controllers/SampleControllerV1.cs
@@ -1,4 +1,4 @@
-﻿// ------------------------------------------------------------
+﻿ // ------------------------------------------------------------
 //  Copyright (c) Microsoft Corporation.  All rights reserved.
 //  Licensed under the MIT License (MIT). See License.txt in the repo root for license information.
 // ------------------------------------------------------------
@@ -20,7 +20,7 @@ namespace Microsoft.OpenApi.CSharpAnnotations.DocumentGeneration.Tests.SampleApi
         /// </summary>
         /// <group>Sample V1</group>
         /// <verb>GET</verb>
-        /// <url>http://localhost:9000/V1/samples/{id}?queryBool={queryBool}</url>
+        /// <url>https://myapi.sample.com/V1/samples/{id}?queryBool={queryBool}</url>
         /// <param name="sampleHeaderParam1" cref="float" in="header">Header param 1</param>
         /// <param name="sampleHeaderParam2" cref="string" in="header">Header param 2</param>
         /// <param name="sampleHeaderParam3" cref="string" in="header">Header param 3</param>
@@ -43,7 +43,7 @@ namespace Microsoft.OpenApi.CSharpAnnotations.DocumentGeneration.Tests.SampleApi
         /// </summary>
         /// <group>Sample V1</group>
         /// <verb>GET</verb>
-        /// <url>http://localhost:9000/V1/samples</url>
+        /// <url>https://myapi.sample.com/V1/samples</url>
         /// <param name="sampleHeaderParam1" cref="float" in="header">Header param 1</param>
         /// <param name="sampleHeaderParam2" cref="string" in="header">Header param 2</param>
         /// <param name="sampleHeaderParam3" cref="string" in="header">Header param 3</param>
@@ -62,7 +62,7 @@ namespace Microsoft.OpenApi.CSharpAnnotations.DocumentGeneration.Tests.SampleApi
         /// </summary>
         /// <group>Sample V1</group>
         /// <verb>POST</verb>
-        /// <url>http://localhost:9000/V1/samples</url>
+        /// <url>https://myapi.sample.com/V1/samples</url>
         /// <param name="sampleHeaderParam1" cref="float" in="header">Header param 1</param>
         /// <param name="sampleHeaderParam2" cref="string" in="header">Header param 2</param>
         /// <param name="sampleHeaderParam3" cref="string" in="header">Header param 3</param>
@@ -81,7 +81,7 @@ namespace Microsoft.OpenApi.CSharpAnnotations.DocumentGeneration.Tests.SampleApi
         /// </summary>
         /// <group>Sample V1</group>
         /// <verb>PUT</verb>
-        /// <url>http://localhost:9000/V1/samples/{id}</url>
+        /// <url>https://myapi.sample.com/V1/samples/{id}</url>
         /// <param name="sampleHeaderParam1" cref="float" in="header">Header param 1</param>
         /// <param name="sampleHeaderParam2" cref="string" in="header">Header param 2</param>
         /// <param name="sampleHeaderParam3" cref="string" in="header">Header param 3</param>

--- a/test/Microsoft.OpenApi.CSharpAnnotations.DocumentGeneration.Tests.SampleApis/Controllers/SampleControllerV2.cs
+++ b/test/Microsoft.OpenApi.CSharpAnnotations.DocumentGeneration.Tests.SampleApis/Controllers/SampleControllerV2.cs
@@ -21,7 +21,7 @@ namespace Microsoft.OpenApi.CSharpAnnotations.DocumentGeneration.Tests.SampleApi
         /// </summary>
         /// <group>Sample V2</group>
         /// <verb>DELETE</verb>
-        /// <url>http://localhost:9000/V2/samples/{id}</url>
+        /// <url>https://myapi.sample.com/V2/samples/{id}</url>
         /// <param name="sampleHeaderParam1" cref="float" in="header">Header param 1</param>
         /// <param name="sampleHeaderParam2" cref="string" in="header">Header param 2</param>
         /// <param name="sampleHeaderParam3" cref="string" in="header">Header param 3</param>
@@ -40,7 +40,7 @@ namespace Microsoft.OpenApi.CSharpAnnotations.DocumentGeneration.Tests.SampleApi
         /// </summary>
         /// <group>Sample V2</group>
         /// <verb>GET</verb>
-        /// <url>http://localhost:9000/V2/samples/</url>
+        /// <url>https://myapi.sample.com/V2/samples/</url>
         /// <param name="sampleHeaderParam1" cref="float" in="header">Header param 1</param>
         /// <param name="sampleHeaderParam2" cref="string" in="header">Header param 2</param>
         /// <param name="sampleHeaderParam3" cref="string" in="header">Header param 3</param>
@@ -58,7 +58,7 @@ namespace Microsoft.OpenApi.CSharpAnnotations.DocumentGeneration.Tests.SampleApi
         /// </summary>
         /// <group>Sample V2</group>
         /// <verb>GET</verb>
-        /// <url>http://localhost:9000/V2/samples/{id}?queryString={queryString}</url>
+        /// <url>https://myapi.sample.com/V2/samples/{id}?queryString={queryString}</url>
         /// <param name="sampleHeaderParam1" cref="float" in="header">Header param 1</param>
         /// <param name="sampleHeaderParam2" cref="string" in="header">Header param 2</param>
         /// <param name="sampleHeaderParam3" cref="string" in="header">Header param 3</param>

--- a/test/Microsoft.OpenApi.CSharpAnnotations.DocumentGeneration.Tests.SampleApis/Controllers/SampleControllerV3.cs
+++ b/test/Microsoft.OpenApi.CSharpAnnotations.DocumentGeneration.Tests.SampleApis/Controllers/SampleControllerV3.cs
@@ -21,7 +21,7 @@ namespace Microsoft.OpenApi.CSharpAnnotations.DocumentGeneration.Tests.SampleApi
         /// </summary>
         /// <group>Sample V3</group>
         /// <verb>GET</verb>
-        /// <url>http://localhost:9000/V3/samples/</url>
+        /// <url>https://myapi.sample.com/V3/samples/</url>
         /// <param name="sampleHeaderParam1" cref="float" in="header">Header param 1</param>
         /// <param name="sampleHeaderParam2" cref="string" in="header">Header param 2</param>
         /// <param name="sampleHeaderParam3" cref="string" in="header">Header param 3</param>
@@ -45,7 +45,7 @@ namespace Microsoft.OpenApi.CSharpAnnotations.DocumentGeneration.Tests.SampleApi
         /// </summary>
         /// <group>Sample V3</group>
         /// <verb>GET</verb>
-        /// <url>http://localhost:9000/V3/samples/{id}?queryString={queryString}</url>
+        /// <url>https://myapi.sample.com/V3/samples/{id}?queryString={queryString}</url>
         /// <param name="sampleHeaderParam1" cref="float" in="header">Header param 1</param>
         /// <param name="sampleHeaderParam2" cref="string" in="header">Header param 2</param>
         /// <param name="sampleHeaderParam3" cref="string" in="header">Header param 3</param>

--- a/test/Microsoft.OpenApi.CSharpAnnotations.DocumentGeneration.Tests.SampleApis/Controllers/SampleControllerV4.cs
+++ b/test/Microsoft.OpenApi.CSharpAnnotations.DocumentGeneration.Tests.SampleApis/Controllers/SampleControllerV4.cs
@@ -21,7 +21,7 @@ namespace Microsoft.OpenApi.CSharpAnnotations.DocumentGeneration.Tests.SampleApi
         /// </summary>
         /// <group>Sample V4</group>
         /// <verb>GET</verb>
-        /// <url>http://localhost:9000/V4/samples/</url>
+        /// <url>https://myapi.sample.com/V4/samples/</url>
         /// <param name="sampleHeaderParam1" cref="float" in="header">Header param 1</param>
         /// <param name="sampleHeaderParam2" cref="string" in="header">Header param 2</param>
         /// <param name="sampleHeaderParam3" cref="string" in="header">Header param 3</param>


### PR DESCRIPTION
Our guidance is to annotate with real URL's so that the Swagger UI "Try It Out" test harness works.