### PR TITLE
undocumented path parameters need to be moved in "ValidateInAttribute…

### DIFF
--- a/src/Microsoft.OpenApi.CSharpAnnotations.DocumentGeneration/Microsoft.OpenApi.CSharpAnnotations.DocumentGeneration.csproj
+++ b/src/Microsoft.OpenApi.CSharpAnnotations.DocumentGeneration/Microsoft.OpenApi.CSharpAnnotations.DocumentGeneration.csproj
@@ -10,7 +10,7 @@
         <Company>Microsoft</Company>
         <Title>Microsoft.OpenApi.CSharpAnnotations.DocumentGeneration</Title>
         <PackageId>Microsoft.OpenApi.CSharpAnnotations.DocumentGeneration</PackageId>
-        <Version>1.0.0-beta033</Version>
+        <Version>1.0.0-beta034</Version>
         <Description>Library that translates Visual Studio C# Annotations into .NET objects representing OpenAPI specification.</Description>
         <Copyright>© Microsoft Corporation. All rights reserved.</Copyright>
         <PackageTags>Microsoft.OpenApi.CSharpAnnotations.DocumentGeneration</PackageTags>

--- a/src/Microsoft.OpenApi.CSharpAnnotations.DocumentGeneration/PreprocessingOperationFilters/PopulateInAttributeFilter.cs
+++ b/src/Microsoft.OpenApi.CSharpAnnotations.DocumentGeneration/PreprocessingOperationFilters/PopulateInAttributeFilter.cs
@@ -5,7 +5,6 @@
 
 using System;
 using System.Linq;
-using System.Text.RegularExpressions;
 using System.Xml.Linq;
 using Microsoft.OpenApi.CSharpAnnotations.DocumentGeneration.Exceptions;
 using Microsoft.OpenApi.CSharpAnnotations.DocumentGeneration.Extensions;
@@ -28,12 +27,9 @@ namespace Microsoft.OpenApi.CSharpAnnotations.DocumentGeneration.PreprocessingOp
         /// <param name="settings">The operation filter settings.</param>
         public void Apply(OpenApiPaths paths, XElement element, PreProcessingOperationFilterSettings settings)
         {
-            var paramElements = element.Elements()
-                .Where(p => p.Name == KnownXmlStrings.Param)
-                .ToList();
-
-            var paramElementsWithoutIn = paramElements.Where(
-                    p => p.Attribute(KnownXmlStrings.In)?.Value == null)
+            var paramElementsWithoutIn = element.Elements().Where(
+                    p => p.Name == KnownXmlStrings.Param
+                    && p.Attribute(KnownXmlStrings.In)?.Value == null)
                 .ToList();
 
             var url = element.Elements()
@@ -68,23 +64,6 @@ namespace Microsoft.OpenApi.CSharpAnnotations.DocumentGeneration.PreprocessingOp
                         StringComparison.InvariantCultureIgnoreCase))
                     {
                         paramElement.Add(new XAttribute(KnownXmlStrings.In, KnownXmlStrings.Query));
-                    }
-                }
-
-                var pathParamElements = paramElements
-                    .Where(p => p.Attribute(KnownXmlStrings.In)?.Value == KnownXmlStrings.Path)
-                    .ToList();
-
-                var matches = new Regex(@"\{(.*?)\}").Matches(url.Split('?')[0]);
-
-                foreach (Match match in matches)
-                {
-                    var pathParamNameFromUrl = match.Groups[1].Value;
-
-                    // All path params in the URL must be documented.
-                    if (!pathParamElements.Any(p => p.Attribute(KnownXmlStrings.Name)?.Value == pathParamNameFromUrl))
-                    {
-                        throw new UndocumentedPathParameterException(pathParamNameFromUrl, url);
                     }
                 }
             }

--- a/test/Microsoft.OpenApi.CSharpAnnotations.DocumentGeneration.Tests/OpenApiDocumentGeneratorTests/Input/AnnotationAlternativeParamTags.xml
+++ b/test/Microsoft.OpenApi.CSharpAnnotations.DocumentGeneration.Tests/OpenApiDocumentGeneratorTests/Input/AnnotationAlternativeParamTags.xml
@@ -84,7 +84,7 @@
       <group>Sample V1</group>
       <verb>POST</verb>
       <url>http://localhost:9000/V1/samples/{id}</url>
-      <!-- Use alternative param tags inconjuction with param tags, in value of param id should be filled from url. -->
+      <!-- Use alternative param tags inconjuction with param tags, 'in' value of param id should be filled from url. -->
       <header name="sampleHeaderParam1" cref="T:System.Single">Header param 1</header>
       <param name="sampleHeaderParam2" cref="T:System.String" in="header">Header param 2</param>
       <param name="sampleHeaderParam3" cref="T:System.String" in="header">Header param 3</param>
@@ -107,14 +107,16 @@
       </summary>
       <group>Sample V1</group>
       <verb>PUT</verb>
+      <!-- Use alternative param tags with no corresponding param tags. -->
       <url>http://localhost:9000/V1/samples/{id}</url>
-      <param name="sampleHeaderParam1" cref="T:System.Single" in="header">Header param 1</param>
-      <param name="sampleHeaderParam2" cref="T:System.String" in="header">Header param 2</param>
-      <param name="sampleHeaderParam3" cref="T:System.String" in="header">Header param 3</param>
-      <param name="id" cref="T:System.String" in="path">The object id</param>
-      <param name="sampleObject" in="body">
+      <header name="sampleHeaderParam1" cref="T:System.Single">Header param 1</header>
+      <header name="sampleHeaderParam2" cref="T:System.String">Header param 2</header>
+      <header name="sampleHeaderParam3" cref="T:System.String">Header param 3</header>
+      <pathParam name="id" cref="T:System.String">The object id</pathParam>
+      <requestType>
         <see cref="T:Microsoft.OpenApi.CSharpAnnotations.DocumentGeneration.Tests.Contracts.SampleObject1"/>Sample object
-      </param>
+      </requestType>
+      <!-- ////////////////////////// -->
       <response code="200">
         <see cref="T:Microsoft.OpenApi.CSharpAnnotations.DocumentGeneration.Tests.Contracts.SampleObject1"/>The sample object updated
       </response>


### PR DESCRIPTION
Undocumented path parameters need to be moved in "ValidateInAttributeFilter" so it gets executed after alternate tags with no matching param tags are converted to param tags.

Otherwise for documentation like below, undocumented path error is thrown:

<member name="M:Microsoft.OpenApi.CSharpAnnotations.DocumentGeneration.Tests.SampleApis.Controllers.SampleControllerV1.SamplePut(System.String,Microsoft.OpenApi.CSharpAnnotations.DocumentGeneration.Tests.Contracts.SampleObject1)">
      <summary>
        Sample put
      </summary>
      <group>Sample V1</group>
      <verb>PUT</verb>
      <!-- Use alternative param tags with no corresponding param tags. -->
      <url>http://localhost:9000/V1/samples/{id}</url>
      <header name="sampleHeaderParam1" cref="T:System.Single">Header param 1</header>
      <header name="sampleHeaderParam2" cref="T:System.String">Header param 2</header>
      <header name="sampleHeaderParam3" cref="T:System.String">Header param 3</header>
      <pathParam name="id" cref="T:System.String">The object id</pathParam>
      <requestType>
        <see cref="T:Microsoft.OpenApi.CSharpAnnotations.DocumentGeneration.Tests.Contracts.SampleObject1"/>Sample object
      </requestType>
      <!-- ////////////////////////// -->
      <returns>The sample object 1</returns>
    </member>