### PR TITLE
Handle duplicate properties while generating schema

### DIFF
--- a/src/Microsoft.OpenApi.CSharpAnnotations.DocumentGeneration/Extensions/TypeExtensions.cs
+++ b/src/Microsoft.OpenApi.CSharpAnnotations.DocumentGeneration/Extensions/TypeExtensions.cs
@@ -77,6 +77,26 @@ namespace Microsoft.OpenApi.CSharpAnnotations.DocumentGeneration.Extensions
         }
 
         /// <summary>
+        /// Determines whether the given type implements the given interface type.
+        /// </summary>
+        public static bool ImplementInterface(this Type type, Type interfaceType)
+        {
+            for (Type currentType = type; currentType != null; currentType = currentType.BaseType)
+            {
+                IEnumerable<Type> interfaces = currentType.GetInterfaces();
+                foreach (Type i in interfaces)
+                {
+                    if (i == interfaceType || (i != null && i.ImplementInterface(interfaceType)))
+                    {
+                        return true;
+                    }
+                }
+            }
+
+            return false;
+        }
+
+        /// <summary>
         /// Determines whether the given type is a dictionary.
         /// </summary>
         public static bool IsDictionary(this Type type)

--- a/src/Microsoft.OpenApi.CSharpAnnotations.DocumentGeneration/Microsoft.OpenApi.CSharpAnnotations.DocumentGeneration.csproj
+++ b/src/Microsoft.OpenApi.CSharpAnnotations.DocumentGeneration/Microsoft.OpenApi.CSharpAnnotations.DocumentGeneration.csproj
@@ -10,7 +10,7 @@
         <Company>Microsoft</Company>
         <Title>Microsoft.OpenApi.CSharpAnnotations.DocumentGeneration</Title>
         <PackageId>Microsoft.OpenApi.CSharpAnnotations.DocumentGeneration</PackageId>
-        <Version>1.0.0-beta034</Version>
+        <Version>1.0.0-beta035</Version>
         <Description>Library that translates Visual Studio C# Annotations into .NET objects representing OpenAPI specification.</Description>
         <Copyright>© Microsoft Corporation. All rights reserved.</Copyright>
         <PackageTags>Microsoft.OpenApi.CSharpAnnotations.DocumentGeneration</PackageTags>

--- a/src/Microsoft.OpenApi.CSharpAnnotations.DocumentGeneration/ReferenceRegistries/SchemaReferenceRegistry.cs
+++ b/src/Microsoft.OpenApi.CSharpAnnotations.DocumentGeneration/ReferenceRegistries/SchemaReferenceRegistry.cs
@@ -116,7 +116,7 @@ namespace Microsoft.OpenApi.CSharpAnnotations.DocumentGeneration.ReferenceRegist
                 // We can also assume that the schema is an object type at this point.
                 References[key] = schema;
 
-                var PropertyNameDeclaringTypeMap = new Dictionary<string, Type>();
+                var propertyNameDeclaringTypeMap = new Dictionary<string, Type>();
 
                 foreach (var propertyInfo in input.GetProperties())
                 {
@@ -175,9 +175,9 @@ namespace Microsoft.OpenApi.CSharpAnnotations.DocumentGeneration.ReferenceRegist
 
                     var propertyDeclaringType = propertyInfo.DeclaringType;
 
-                    if (PropertyNameDeclaringTypeMap.ContainsKey(propertyName))
+                    if (propertyNameDeclaringTypeMap.ContainsKey(propertyName))
                     {
-                        var existingPropertyDeclaringType = PropertyNameDeclaringTypeMap[propertyName];
+                        var existingPropertyDeclaringType = propertyNameDeclaringTypeMap[propertyName];
                         bool duplicateProperty = true;
 
                         if (existingPropertyDeclaringType != null && propertyDeclaringType != null)
@@ -212,7 +212,7 @@ namespace Microsoft.OpenApi.CSharpAnnotations.DocumentGeneration.ReferenceRegist
                     }
 
                     schema.Properties[propertyName] = innerSchema;
-                    PropertyNameDeclaringTypeMap.Add(propertyName, propertyDeclaringType);
+                    propertyNameDeclaringTypeMap.Add(propertyName, propertyDeclaringType);
                 }
 
                 References[key] = schema;

--- a/src/Microsoft.OpenApi.CSharpAnnotations.DocumentGeneration/ReferenceRegistries/SchemaReferenceRegistry.cs
+++ b/src/Microsoft.OpenApi.CSharpAnnotations.DocumentGeneration/ReferenceRegistries/SchemaReferenceRegistry.cs
@@ -116,6 +116,8 @@ namespace Microsoft.OpenApi.CSharpAnnotations.DocumentGeneration.ReferenceRegist
                 // We can also assume that the schema is an object type at this point.
                 References[key] = schema;
 
+                var PropertyNameDeclaringTypeMap = new Dictionary<string, Type>();
+
                 foreach (var propertyInfo in input.GetProperties())
                 {
                     var ignoreProperty = false;
@@ -166,10 +168,51 @@ namespace Microsoft.OpenApi.CSharpAnnotations.DocumentGeneration.ReferenceRegist
                         }
                     }
 
-                    if (!ignoreProperty)
+                    if (ignoreProperty)
                     {
-                        schema.Properties[propertyName] = innerSchema;
+                        continue;
                     }
+
+                    var propertyDeclaringType = propertyInfo.DeclaringType;
+
+                    if (PropertyNameDeclaringTypeMap.ContainsKey(propertyName))
+                    {
+                        var existingPropertyDeclaringType = PropertyNameDeclaringTypeMap[propertyName];
+                        bool duplicateProperty = true;
+
+                        if (existingPropertyDeclaringType != null && propertyDeclaringType != null)
+                        {
+                            if (propertyDeclaringType.IsSubclassOf(existingPropertyDeclaringType)
+                                || (existingPropertyDeclaringType.IsInterface
+                                && propertyDeclaringType.ImplementInterface(existingPropertyDeclaringType)))
+                            {
+                                // Current property is on a derived class and hides the existing
+                                schema.Properties[propertyName] = innerSchema;
+                                duplicateProperty = false;
+                            }
+
+                            if (existingPropertyDeclaringType.IsSubclassOf(propertyDeclaringType)
+                                || (propertyDeclaringType.IsInterface
+                                && existingPropertyDeclaringType.ImplementInterface(propertyDeclaringType)))
+                            {
+                                // current property is hidden by the existing so don't add it
+                                continue;
+                            }
+                        }
+
+                        if (duplicateProperty)
+                        {
+                            throw new AddingSchemaReferenceFailedException(
+                                key,
+                                string.Format(
+                                    SpecificationGenerationMessages.DuplicateProperty,
+                                    propertyName,
+                                    input));
+                        }
+                    }
+
+                    schema.Properties[propertyName] = innerSchema;
+                    PropertyNameDeclaringTypeMap.Add(propertyName, propertyDeclaringType);
                 }
 
                 References[key] = schema;

--- a/src/Microsoft.OpenApi.CSharpAnnotations.DocumentGeneration/SpecificationGenerationMessages.cs
+++ b/src/Microsoft.OpenApi.CSharpAnnotations.DocumentGeneration/SpecificationGenerationMessages.cs
@@ -25,6 +25,8 @@ namespace Microsoft.OpenApi.CSharpAnnotations.DocumentGeneration
 
         public const string DuplicateOperation = "There are duplicates for the operation: \"{0}\" \"{1}\"";
 
+        public const string DuplicateProperty = "A property with the name \"{0}\" already exists on \"{1}\"";
+
         public const string FilterSetVersionNotSupported = "Provided filter set version: \"{0}\" is not supported.";
 
         public const string InvalidHttpMethod = "The documented verb \"{0}\" is not a valid http Method.";

--- a/test/Microsoft.OpenApi.CSharpAnnotations.DocumentGeneration.Tests/ReferenceRegistryTests/Types/ISampleInterface.cs
+++ b/test/Microsoft.OpenApi.CSharpAnnotations.DocumentGeneration.Tests/ReferenceRegistryTests/Types/ISampleInterface.cs
@@ -1,0 +1,11 @@
+﻿//  Copyright (c) Microsoft Corporation.  All rights reserved.
+//  Licensed under the MIT License (MIT). See LICENSE in the repo root for license information.
+// ------------------------------------------------------------
+
+namespace Microsoft.OpenApi.CSharpAnnotations.DocumentGeneration.Tests.ReferenceRegistryTests.Types
+{
+    internal interface ISampleInterface
+    {
+       string SampleProperty { get; }
+    }
+}

--- a/test/Microsoft.OpenApi.CSharpAnnotations.DocumentGeneration.Tests/ReferenceRegistryTests/Types/SampleBaseType1.cs
+++ b/test/Microsoft.OpenApi.CSharpAnnotations.DocumentGeneration.Tests/ReferenceRegistryTests/Types/SampleBaseType1.cs
@@ -1,0 +1,65 @@
+﻿// ------------------------------------------------------------
+//  Copyright (c) Microsoft Corporation.  All rights reserved.
+//  Licensed under the MIT License (MIT). See LICENSE in the repo root for license information.
+// ------------------------------------------------------------
+
+using System.Collections.Generic;
+using Microsoft.OpenApi.CSharpAnnotations.DocumentGeneration.Extensions;
+using Microsoft.OpenApi.Models;
+using Newtonsoft.Json;
+
+namespace Microsoft.OpenApi.CSharpAnnotations.DocumentGeneration.Tests.ReferenceRegistryTests.Types
+{
+    internal class SampleBaseType1
+    {
+        public static readonly OpenApiSchema schema = new OpenApiSchema
+        {
+            Type = "object",
+            Properties = new Dictionary<string, OpenApiSchema>
+            {
+                ["sampleList"] = new OpenApiSchema
+                {
+                    Type = "array",
+                    ReadOnly = true,
+                    Items = new OpenApiSchema
+                    {
+                        Reference = new OpenApiReference
+                        {
+                            Type = ReferenceType.Schema,
+                            Id = typeof(SampleBaseType2).ToString().SanitizeClassName()
+                        }
+                    }
+                },
+                ["SampleStringList"] = new OpenApiSchema
+                {
+                    Type = "array",
+                    ReadOnly = true,
+                    Items = new OpenApiSchema
+                    {
+                        Type = "string"
+                    }
+                },
+                ["SampleList2"] = new OpenApiSchema
+                {
+                    Type = "array",
+                    ReadOnly = true,
+                    Items = new OpenApiSchema
+                    {
+                        Reference = new OpenApiReference
+                        {
+                            Type = ReferenceType.Schema,
+                            Id = typeof(SampleBaseType2).ToString().SanitizeClassName()
+                        }
+                    }
+                }
+            }
+        };
+
+        [JsonProperty("sampleList")]
+        public IList<SampleBaseType2> SampleList { get; }
+
+        public IList<string> SampleStringList { get; }
+
+        public IList<SampleBaseType2> SampleList2 { get; }
+    }
+}

--- a/test/Microsoft.OpenApi.CSharpAnnotations.DocumentGeneration.Tests/ReferenceRegistryTests/Types/SampleBaseType2.cs
+++ b/test/Microsoft.OpenApi.CSharpAnnotations.DocumentGeneration.Tests/ReferenceRegistryTests/Types/SampleBaseType2.cs
@@ -1,0 +1,46 @@
+﻿// ------------------------------------------------------------
+//  Copyright (c) Microsoft Corporation.  All rights reserved.
+//  Licensed under the MIT License (MIT). See LICENSE in the repo root for license information.
+// ------------------------------------------------------------
+
+using System.Collections.Generic;
+using Microsoft.OpenApi.Models;
+using Newtonsoft.Json;
+
+namespace Microsoft.OpenApi.CSharpAnnotations.DocumentGeneration.Tests.ReferenceRegistryTests.Types
+{
+    internal class SampleBaseType2
+    {
+        public static readonly OpenApiSchema schema = new OpenApiSchema
+        {
+            Type = "object",
+            Properties = new Dictionary<string, OpenApiSchema>
+            {
+                ["sampleList"] = new OpenApiSchema
+                {
+                    Type = "array",
+                    ReadOnly = true,
+                    Items = new OpenApiSchema
+                    {
+                        Type = "string"
+                    }
+                },
+                ["SampleList2"] = new OpenApiSchema
+                {
+                    Type = "array",
+                    ReadOnly = true,
+                    Items = new OpenApiSchema
+                    {
+                        Type = "integer",
+                        Format = "int32"
+                    }
+                }
+            }
+        };
+
+        [JsonProperty("sampleList")]
+        public IList<string> SampleStringList { get; }
+
+        public IList<int> SampleList2 { get; }
+    }
+}

--- a/test/Microsoft.OpenApi.CSharpAnnotations.DocumentGeneration.Tests/ReferenceRegistryTests/Types/SampleChildType1.cs
+++ b/test/Microsoft.OpenApi.CSharpAnnotations.DocumentGeneration.Tests/ReferenceRegistryTests/Types/SampleChildType1.cs
@@ -1,0 +1,72 @@
+﻿// ------------------------------------------------------------
+//  Copyright (c) Microsoft Corporation.  All rights reserved.
+//  Licensed under the MIT License (MIT). See LICENSE in the repo root for license information.
+// ------------------------------------------------------------
+
+using System.Collections.Generic;
+using Microsoft.OpenApi.CSharpAnnotations.DocumentGeneration.Extensions;
+using Microsoft.OpenApi.Models;
+using Newtonsoft.Json;
+
+namespace Microsoft.OpenApi.CSharpAnnotations.DocumentGeneration.Tests.ReferenceRegistryTests.Types
+{
+    internal class SampleChildType1 : SampleBaseType1, ISampleInterface
+    {
+        public new static readonly OpenApiSchema schema = new OpenApiSchema
+        {
+            Type = "object",
+            Properties = new Dictionary<string, OpenApiSchema>
+            {
+                ["sampleList"] = new OpenApiSchema
+                {
+                    Type = "array",
+                    ReadOnly = true,
+                    Items = new OpenApiSchema
+                    {
+                        Reference = new OpenApiReference
+                        {
+                            Type = ReferenceType.Schema,
+                            Id = typeof(SampleChildType2).ToString().SanitizeClassName()
+                        }
+                    }
+                },
+                ["SampleStringList"] = new OpenApiSchema
+                {
+                    Type = "array",
+                    ReadOnly = true,
+                    Items = new OpenApiSchema
+                    {
+                        Type = "string"
+                    }
+                },
+                ["SampleList2"] = new OpenApiSchema
+                {
+                    Type = "array",
+                    ReadOnly = true,
+                    Items = new OpenApiSchema
+                    {
+                        Reference = new OpenApiReference
+                        {
+                            Type = ReferenceType.Schema,
+                            Id = typeof(SampleBaseType2).ToString().SanitizeClassName()
+                        }
+                    }
+                },
+                ["SampleProperty"] = new OpenApiSchema
+                {
+                    ReadOnly = true,
+                    Type = "string"
+                }
+            }
+        };
+
+        [JsonProperty("sampleList")]
+        public new IList<SampleChildType2> SampleList { get; }
+
+        // Conflicting property in Child class but its ignored so the property from base class should be used in schema.
+        [JsonIgnore]
+        public new IList<SampleChildType2> SampleList2 { get; }
+
+        public string SampleProperty => throw new System.NotImplementedException();
+    }
+}

--- a/test/Microsoft.OpenApi.CSharpAnnotations.DocumentGeneration.Tests/ReferenceRegistryTests/Types/SampleChildType2.cs
+++ b/test/Microsoft.OpenApi.CSharpAnnotations.DocumentGeneration.Tests/ReferenceRegistryTests/Types/SampleChildType2.cs
@@ -1,0 +1,46 @@
+﻿// ------------------------------------------------------------
+//  Copyright (c) Microsoft Corporation.  All rights reserved.
+//  Licensed under the MIT License (MIT). See LICENSE in the repo root for license information.
+// ------------------------------------------------------------
+
+using System.Collections.Generic;
+using Microsoft.OpenApi.Models;
+using Newtonsoft.Json;
+
+namespace Microsoft.OpenApi.CSharpAnnotations.DocumentGeneration.Tests.ReferenceRegistryTests.Types
+{
+    internal class SampleChildType2 : SampleBaseType2
+    {
+        public new static readonly OpenApiSchema schema = new OpenApiSchema
+        {
+            Type = "object",
+            Properties = new Dictionary<string, OpenApiSchema>
+            {
+                ["sampleList"] = new OpenApiSchema
+                {
+                    Type = "array",
+                    ReadOnly = true,
+                    Items = new OpenApiSchema
+                    {
+                        Type = "integer",
+                        Format = "int32"
+                    }
+                },
+                ["SampleList2"] = new OpenApiSchema
+                {
+                    Type = "array",
+                    ReadOnly = true,
+                    Items = new OpenApiSchema
+                    {
+                        Type = "string"
+                    }
+                }
+            }
+        };
+
+        [JsonProperty("sampleList")]
+        public IList<int> SampleIntList { get; }
+
+        public new IList<string> SampleList2 { get; }
+    }
+}

--- a/test/Microsoft.OpenApi.CSharpAnnotations.DocumentGeneration.Tests/ReferenceRegistryTests/Types/SampleGenericType.cs
+++ b/test/Microsoft.OpenApi.CSharpAnnotations.DocumentGeneration.Tests/ReferenceRegistryTests/Types/SampleGenericType.cs
@@ -3,9 +3,7 @@
 //  Licensed under the MIT License (MIT). See LICENSE in the repo root for license information.
 // ------------------------------------------------------------
 
-using System;
 using System.Collections.Generic;
-using Microsoft.OpenApi.Any;
 using Microsoft.OpenApi.Models;
 
 namespace Microsoft.OpenApi.CSharpAnnotations.DocumentGeneration.Tests.ReferenceRegistryTests.Types

--- a/test/Microsoft.OpenApi.CSharpAnnotations.DocumentGeneration.Tests/ReferenceRegistryTests/Types/SampleTypeWithDuplicateProperty.cs
+++ b/test/Microsoft.OpenApi.CSharpAnnotations.DocumentGeneration.Tests/ReferenceRegistryTests/Types/SampleTypeWithDuplicateProperty.cs
@@ -1,0 +1,18 @@
+﻿//  Copyright (c) Microsoft Corporation.  All rights reserved.
+//  Licensed under the MIT License (MIT). See LICENSE in the repo root for license information.
+// ------------------------------------------------------------
+
+using System.Collections.Generic;
+using Newtonsoft.Json;
+
+namespace Microsoft.OpenApi.CSharpAnnotations.DocumentGeneration.Tests.ReferenceRegistryTests.Types
+{
+    public class SampleTypeWithDuplicateProperty
+    {
+        [JsonProperty("sampleList")]
+        public IList<string> SampleStringList { get; }
+
+        [JsonProperty("sampleList")]
+        public IList<int> SampleList2 { get; }
+    }
+}


### PR DESCRIPTION
Code changes
- To handle case where both base class and child class have property with same name.
- Throw error when legitimate duplicate properties are found.