### PR TITLE
FixReadOnlyAndReadJObjectAttribute

### DIFF
--- a/test/Microsoft.OpenApi.CSharpAnnotations.DocumentGeneration.Tests/DocumentVariantTests/Output/AnnotationDefaultVariant.json
+++ b/test/Microsoft.OpenApi.CSharpAnnotations.DocumentGeneration.Tests/DocumentVariantTests/Output/AnnotationDefaultVariant.json
@@ -684,8 +684,7 @@
             "items": {
               "$ref": "#/components/schemas/Microsoft.OpenApi.CSharpAnnotations.DocumentGeneration.Tests.Contracts.SampleObject1"
             },
-            "description": "Gets the sample property object list",
-            "readOnly": true
+            "description": "Gets the sample property object list"
           }
         }
       },
@@ -714,16 +713,14 @@
             "additionalProperties": {
               "$ref": "#/components/schemas/Microsoft.OpenApi.CSharpAnnotations.DocumentGeneration.Tests.Contracts.SampleObject1"
             },
-            "description": "Gets the sample property object dictionary",
-            "readOnly": true
+            "description": "Gets the sample property object dictionary"
           },
           "samplePropertyObjectList": {
             "type": "array",
             "items": {
               "$ref": "#/components/schemas/Microsoft.OpenApi.CSharpAnnotations.DocumentGeneration.Tests.Contracts.SampleObject1"
             },
-            "description": "Gets the sample property object list",
-            "readOnly": true
+            "description": "Gets the sample property object list"
           },
           "samplePropertyString1": {
             "type": "string",

--- a/test/Microsoft.OpenApi.CSharpAnnotations.DocumentGeneration.Tests/DocumentVariantTests/Output/AnnotationVariantSwaggerGroup1.json
+++ b/test/Microsoft.OpenApi.CSharpAnnotations.DocumentGeneration.Tests/DocumentVariantTests/Output/AnnotationVariantSwaggerGroup1.json
@@ -204,8 +204,7 @@
             "items": {
               "$ref": "#/components/schemas/Microsoft.OpenApi.CSharpAnnotations.DocumentGeneration.Tests.Contracts.SampleObject1"
             },
-            "description": "Gets the sample property object list",
-            "readOnly": true
+            "description": "Gets the sample property object list"
           }
         }
       },
@@ -234,16 +233,14 @@
             "additionalProperties": {
               "$ref": "#/components/schemas/Microsoft.OpenApi.CSharpAnnotations.DocumentGeneration.Tests.Contracts.SampleObject1"
             },
-            "description": "Gets the sample property object dictionary",
-            "readOnly": true
+            "description": "Gets the sample property object dictionary"
           },
           "samplePropertyObjectList": {
             "type": "array",
             "items": {
               "$ref": "#/components/schemas/Microsoft.OpenApi.CSharpAnnotations.DocumentGeneration.Tests.Contracts.SampleObject1"
             },
-            "description": "Gets the sample property object list",
-            "readOnly": true
+            "description": "Gets the sample property object list"
           },
           "samplePropertyString1": {
             "type": "string",

--- a/test/Microsoft.OpenApi.CSharpAnnotations.DocumentGeneration.Tests/DocumentVariantTests/Output/AnnotationVariantSwaggerGroup2.json
+++ b/test/Microsoft.OpenApi.CSharpAnnotations.DocumentGeneration.Tests/DocumentVariantTests/Output/AnnotationVariantSwaggerGroup2.json
@@ -204,8 +204,7 @@
             "items": {
               "$ref": "#/components/schemas/Microsoft.OpenApi.CSharpAnnotations.DocumentGeneration.Tests.Contracts.SampleObject1"
             },
-            "description": "Gets the sample property object list",
-            "readOnly": true
+            "description": "Gets the sample property object list"
           }
         }
       },
@@ -234,16 +233,14 @@
             "additionalProperties": {
               "$ref": "#/components/schemas/Microsoft.OpenApi.CSharpAnnotations.DocumentGeneration.Tests.Contracts.SampleObject1"
             },
-            "description": "Gets the sample property object dictionary",
-            "readOnly": true
+            "description": "Gets the sample property object dictionary"
           },
           "samplePropertyObjectList": {
             "type": "array",
             "items": {
               "$ref": "#/components/schemas/Microsoft.OpenApi.CSharpAnnotations.DocumentGeneration.Tests.Contracts.SampleObject1"
             },
-            "description": "Gets the sample property object list",
-            "readOnly": true
+            "description": "Gets the sample property object list"
           },
           "samplePropertyString1": {
             "type": "string",

--- a/test/Microsoft.OpenApi.CSharpAnnotations.DocumentGeneration.Tests/DocumentVariantTests/Output/AnnotationsWithCommonAnnotations/AnnotationDefaultVariant.json
+++ b/test/Microsoft.OpenApi.CSharpAnnotations.DocumentGeneration.Tests/DocumentVariantTests/Output/AnnotationsWithCommonAnnotations/AnnotationDefaultVariant.json
@@ -756,8 +756,7 @@
             "items": {
               "$ref": "#/components/schemas/Microsoft.OpenApi.CSharpAnnotations.DocumentGeneration.Tests.Contracts.SampleObject1"
             },
-            "description": "Gets the sample property object list",
-            "readOnly": true
+            "description": "Gets the sample property object list"
           }
         }
       },
@@ -786,16 +785,14 @@
             "additionalProperties": {
               "$ref": "#/components/schemas/Microsoft.OpenApi.CSharpAnnotations.DocumentGeneration.Tests.Contracts.SampleObject1"
             },
-            "description": "Gets the sample property object dictionary",
-            "readOnly": true
+            "description": "Gets the sample property object dictionary"
           },
           "samplePropertyObjectList": {
             "type": "array",
             "items": {
               "$ref": "#/components/schemas/Microsoft.OpenApi.CSharpAnnotations.DocumentGeneration.Tests.Contracts.SampleObject1"
             },
-            "description": "Gets the sample property object list",
-            "readOnly": true
+            "description": "Gets the sample property object list"
           },
           "samplePropertyString1": {
             "type": "string",

--- a/test/Microsoft.OpenApi.CSharpAnnotations.DocumentGeneration.Tests/DocumentVariantTests/Output/AnnotationsWithCommonAnnotations/AnnotationVariantSwaggerGroup1.json
+++ b/test/Microsoft.OpenApi.CSharpAnnotations.DocumentGeneration.Tests/DocumentVariantTests/Output/AnnotationsWithCommonAnnotations/AnnotationVariantSwaggerGroup1.json
@@ -220,8 +220,8 @@
             "items": {
               "$ref": "#/components/schemas/Microsoft.OpenApi.CSharpAnnotations.DocumentGeneration.Tests.Contracts.SampleObject1"
             },
-            "description": "Gets the sample property object list",
-            "readOnly": true
+            "description": "Gets the sample property object list"
+
           }
         }
       },
@@ -250,16 +250,14 @@
             "additionalProperties": {
               "$ref": "#/components/schemas/Microsoft.OpenApi.CSharpAnnotations.DocumentGeneration.Tests.Contracts.SampleObject1"
             },
-            "description": "Gets the sample property object dictionary",
-            "readOnly": true
+            "description": "Gets the sample property object dictionary"
           },
           "samplePropertyObjectList": {
             "type": "array",
             "items": {
               "$ref": "#/components/schemas/Microsoft.OpenApi.CSharpAnnotations.DocumentGeneration.Tests.Contracts.SampleObject1"
             },
-            "description": "Gets the sample property object list",
-            "readOnly": true
+            "description": "Gets the sample property object list"
           },
           "samplePropertyString1": {
             "type": "string",

--- a/test/Microsoft.OpenApi.CSharpAnnotations.DocumentGeneration.Tests/DocumentVariantTests/Output/AnnotationsWithCommonAnnotations/AnnotationVariantSwaggerGroup2.json
+++ b/test/Microsoft.OpenApi.CSharpAnnotations.DocumentGeneration.Tests/DocumentVariantTests/Output/AnnotationsWithCommonAnnotations/AnnotationVariantSwaggerGroup2.json
@@ -220,8 +220,7 @@
             "items": {
               "$ref": "#/components/schemas/Microsoft.OpenApi.CSharpAnnotations.DocumentGeneration.Tests.Contracts.SampleObject1"
             },
-            "description": "Gets the sample property object list",
-            "readOnly": true
+            "description": "Gets the sample property object list"
           }
         }
       },
@@ -250,16 +249,14 @@
             "additionalProperties": {
               "$ref": "#/components/schemas/Microsoft.OpenApi.CSharpAnnotations.DocumentGeneration.Tests.Contracts.SampleObject1"
             },
-            "description": "Gets the sample property object dictionary",
-            "readOnly": true
+            "description": "Gets the sample property object dictionary"
           },
           "samplePropertyObjectList": {
             "type": "array",
             "items": {
               "$ref": "#/components/schemas/Microsoft.OpenApi.CSharpAnnotations.DocumentGeneration.Tests.Contracts.SampleObject1"
             },
-            "description": "Gets the sample property object list",
-            "readOnly": true
+            "description": "Gets the sample property object list"
           },
           "samplePropertyString1": {
             "type": "string",

--- a/test/Microsoft.OpenApi.CSharpAnnotations.DocumentGeneration.Tests/DocumentVariantTests/Output/AnnotationsWithDuplicatePaths/AnnotationDefaultVariant.json
+++ b/test/Microsoft.OpenApi.CSharpAnnotations.DocumentGeneration.Tests/DocumentVariantTests/Output/AnnotationsWithDuplicatePaths/AnnotationDefaultVariant.json
@@ -271,8 +271,7 @@
             "items": {
               "$ref": "#/components/schemas/Microsoft.OpenApi.CSharpAnnotations.DocumentGeneration.Tests.Contracts.SampleObject1"
             },
-            "description": "Gets the sample property object list",
-            "readOnly": true
+            "description": "Gets the sample property object list"
           }
         }
       },
@@ -301,16 +300,14 @@
             "additionalProperties": {
               "$ref": "#/components/schemas/Microsoft.OpenApi.CSharpAnnotations.DocumentGeneration.Tests.Contracts.SampleObject1"
             },
-            "description": "Gets the sample property object dictionary",
-            "readOnly": true
+            "description": "Gets the sample property object dictionary"
           },
           "samplePropertyObjectList": {
             "type": "array",
             "items": {
               "$ref": "#/components/schemas/Microsoft.OpenApi.CSharpAnnotations.DocumentGeneration.Tests.Contracts.SampleObject1"
             },
-            "description": "Gets the sample property object list",
-            "readOnly": true
+            "description": "Gets the sample property object list"
           },
           "samplePropertyString1": {
             "type": "string",

--- a/test/Microsoft.OpenApi.CSharpAnnotations.DocumentGeneration.Tests/DocumentVariantTests/Output/AnnotationsWithDuplicatePaths/AnnotationVariantSwaggerGroup2.json
+++ b/test/Microsoft.OpenApi.CSharpAnnotations.DocumentGeneration.Tests/DocumentVariantTests/Output/AnnotationsWithDuplicatePaths/AnnotationVariantSwaggerGroup2.json
@@ -161,8 +161,7 @@
             "items": {
               "$ref": "#/components/schemas/Microsoft.OpenApi.CSharpAnnotations.DocumentGeneration.Tests.Contracts.SampleObject1"
             },
-            "description": "Gets the sample property object list",
-            "readOnly": true
+            "description": "Gets the sample property object list"
           }
         }
       },
@@ -191,16 +190,14 @@
             "additionalProperties": {
               "$ref": "#/components/schemas/Microsoft.OpenApi.CSharpAnnotations.DocumentGeneration.Tests.Contracts.SampleObject1"
             },
-            "description": "Gets the sample property object dictionary",
-            "readOnly": true
+            "description": "Gets the sample property object dictionary"
           },
           "samplePropertyObjectList": {
             "type": "array",
             "items": {
               "$ref": "#/components/schemas/Microsoft.OpenApi.CSharpAnnotations.DocumentGeneration.Tests.Contracts.SampleObject1"
             },
-            "description": "Gets the sample property object list",
-            "readOnly": true
+            "description": "Gets the sample property object list"
           },
           "samplePropertyString1": {
             "type": "string",

--- a/test/Microsoft.OpenApi.CSharpAnnotations.DocumentGeneration.Tests/OpenApiDocumentGeneratorTests/Output/Annotation.Json
+++ b/test/Microsoft.OpenApi.CSharpAnnotations.DocumentGeneration.Tests/OpenApiDocumentGeneratorTests/Output/Annotation.Json
@@ -712,16 +712,14 @@
             "additionalProperties": {
               "$ref": "#/components/schemas/Microsoft.OpenApi.CSharpAnnotations.DocumentGeneration.Tests.Contracts.SampleObject1"
             },
-            "description": "Gets the sample property object dictionary",
-            "readOnly": true
+            "description": "Gets the sample property object dictionary"
           },
           "samplePropertyObjectList": {
             "type": "array",
             "items": {
               "$ref": "#/components/schemas/Microsoft.OpenApi.CSharpAnnotations.DocumentGeneration.Tests.Contracts.SampleObject1"
             },
-            "description": "Gets the sample property object list",
-            "readOnly": true
+            "description": "Gets the sample property object list"
           },
           "samplePropertyString1": {
             "type": "string",
@@ -743,8 +741,7 @@
             "items": {
               "$ref": "#/components/schemas/Microsoft.OpenApi.CSharpAnnotations.DocumentGeneration.Tests.Contracts.SampleObject1"
             },
-            "description": "Gets the sample property object list",
-            "readOnly": true
+            "description": "Gets the sample property object list"
           }
         }
       }

--- a/test/Microsoft.OpenApi.CSharpAnnotations.DocumentGeneration.Tests/OpenApiDocumentGeneratorTests/Output/AnnotationAlternativeParamTags.Json
+++ b/test/Microsoft.OpenApi.CSharpAnnotations.DocumentGeneration.Tests/OpenApiDocumentGeneratorTests/Output/AnnotationAlternativeParamTags.Json
@@ -693,8 +693,7 @@
             "items": {
               "$ref": "#/components/schemas/Microsoft.OpenApi.CSharpAnnotations.DocumentGeneration.Tests.Contracts.SampleObject1"
             },
-            "description": "Gets the sample property object list",
-            "readOnly": true
+            "description": "Gets the sample property object list"
           }
         }
       },
@@ -723,16 +722,14 @@
             "additionalProperties": {
               "$ref": "#/components/schemas/Microsoft.OpenApi.CSharpAnnotations.DocumentGeneration.Tests.Contracts.SampleObject1"
             },
-            "description": "Gets the sample property object dictionary",
-            "readOnly": true
+            "description": "Gets the sample property object dictionary"
           },
           "samplePropertyObjectList": {
             "type": "array",
             "items": {
               "$ref": "#/components/schemas/Microsoft.OpenApi.CSharpAnnotations.DocumentGeneration.Tests.Contracts.SampleObject1"
             },
-            "description": "Gets the sample property object list",
-            "readOnly": true
+            "description": "Gets the sample property object list"
           },
           "samplePropertyString1": {
             "type": "string",

--- a/test/Microsoft.OpenApi.CSharpAnnotations.DocumentGeneration.Tests/OpenApiDocumentGeneratorTests/Output/AnnotationArrayInParamTags.Json
+++ b/test/Microsoft.OpenApi.CSharpAnnotations.DocumentGeneration.Tests/OpenApiDocumentGeneratorTests/Output/AnnotationArrayInParamTags.Json
@@ -687,8 +687,7 @@
             "items": {
               "$ref": "#/components/schemas/Microsoft.OpenApi.CSharpAnnotations.DocumentGeneration.Tests.Contracts.SampleObject1"
             },
-            "description": "Gets the sample property object list",
-            "readOnly": true
+            "description": "Gets the sample property object list"
           }
         }
       },
@@ -717,16 +716,14 @@
             "additionalProperties": {
               "$ref": "#/components/schemas/Microsoft.OpenApi.CSharpAnnotations.DocumentGeneration.Tests.Contracts.SampleObject1"
             },
-            "description": "Gets the sample property object dictionary",
-            "readOnly": true
+            "description": "Gets the sample property object dictionary"
           },
           "samplePropertyObjectList": {
             "type": "array",
             "items": {
               "$ref": "#/components/schemas/Microsoft.OpenApi.CSharpAnnotations.DocumentGeneration.Tests.Contracts.SampleObject1"
             },
-            "description": "Gets the sample property object list",
-            "readOnly": true
+            "description": "Gets the sample property object list"
           },
           "samplePropertyString1": {
             "type": "string",

--- a/test/Microsoft.OpenApi.CSharpAnnotations.DocumentGeneration.Tests/OpenApiDocumentGeneratorTests/Output/AnnotationCamelCase.Json
+++ b/test/Microsoft.OpenApi.CSharpAnnotations.DocumentGeneration.Tests/OpenApiDocumentGeneratorTests/Output/AnnotationCamelCase.Json
@@ -712,16 +712,14 @@
             "additionalProperties": {
               "$ref": "#/components/schemas/Microsoft.OpenApi.CSharpAnnotations.DocumentGeneration.Tests.Contracts.SampleObject1"
             },
-            "description": "Gets the sample property object dictionary",
-            "readOnly": true
+            "description": "Gets the sample property object dictionary"
           },
           "samplePropertyObjectList": {
             "type": "array",
             "items": {
               "$ref": "#/components/schemas/Microsoft.OpenApi.CSharpAnnotations.DocumentGeneration.Tests.Contracts.SampleObject1"
             },
-            "description": "Gets the sample property object list",
-            "readOnly": true
+            "description": "Gets the sample property object list"
           },
           "samplePropertyString1": {
             "type": "string",
@@ -743,8 +741,7 @@
             "items": {
               "$ref": "#/components/schemas/Microsoft.OpenApi.CSharpAnnotations.DocumentGeneration.Tests.Contracts.SampleObject1"
             },
-            "description": "Gets the sample property object list",
-            "readOnly": true
+            "description": "Gets the sample property object list"
           }
         }
       }

--- a/test/Microsoft.OpenApi.CSharpAnnotations.DocumentGeneration.Tests/OpenApiDocumentGeneratorTests/Output/AnnotationConflictingPathAndQueryParameters.json
+++ b/test/Microsoft.OpenApi.CSharpAnnotations.DocumentGeneration.Tests/OpenApiDocumentGeneratorTests/Output/AnnotationConflictingPathAndQueryParameters.json
@@ -610,8 +610,7 @@
             "items": {
               "$ref": "#/components/schemas/Microsoft.OpenApi.CSharpAnnotations.DocumentGeneration.Tests.Contracts.SampleObject1"
             },
-            "description": "Gets the sample property object list",
-            "readOnly": true
+            "description": "Gets the sample property object list"
           }
         }
       },
@@ -640,16 +639,14 @@
             "additionalProperties": {
               "$ref": "#/components/schemas/Microsoft.OpenApi.CSharpAnnotations.DocumentGeneration.Tests.Contracts.SampleObject1"
             },
-            "description": "Gets the sample property object dictionary",
-            "readOnly": true
+            "description": "Gets the sample property object dictionary"
           },
           "samplePropertyObjectList": {
             "type": "array",
             "items": {
               "$ref": "#/components/schemas/Microsoft.OpenApi.CSharpAnnotations.DocumentGeneration.Tests.Contracts.SampleObject1"
             },
-            "description": "Gets the sample property object list",
-            "readOnly": true
+            "description": "Gets the sample property object list"
           },
           "samplePropertyString1": {
             "type": "string",

--- a/test/Microsoft.OpenApi.CSharpAnnotations.DocumentGeneration.Tests/OpenApiDocumentGeneratorTests/Output/AnnotationIncorrectlyOrderedGeneric.json
+++ b/test/Microsoft.OpenApi.CSharpAnnotations.DocumentGeneration.Tests/OpenApiDocumentGeneratorTests/Output/AnnotationIncorrectlyOrderedGeneric.json
@@ -623,8 +623,7 @@
             "items": {
               "$ref": "#/components/schemas/Microsoft.OpenApi.CSharpAnnotations.DocumentGeneration.Tests.Contracts.SampleObject1"
             },
-            "description": "Gets the sample property object list",
-            "readOnly": true
+            "description": "Gets the sample property object list"
           }
         }
       },
@@ -653,16 +652,14 @@
             "additionalProperties": {
               "$ref": "#/components/schemas/Microsoft.OpenApi.CSharpAnnotations.DocumentGeneration.Tests.Contracts.SampleObject1"
             },
-            "description": "Gets the sample property object dictionary",
-            "readOnly": true
+            "description": "Gets the sample property object dictionary"
           },
           "samplePropertyObjectList": {
             "type": "array",
             "items": {
               "$ref": "#/components/schemas/Microsoft.OpenApi.CSharpAnnotations.DocumentGeneration.Tests.Contracts.SampleObject1"
             },
-            "description": "Gets the sample property object list",
-            "readOnly": true
+            "description": "Gets the sample property object list"
           },
           "samplePropertyString1": {
             "type": "string",

--- a/test/Microsoft.OpenApi.CSharpAnnotations.DocumentGeneration.Tests/OpenApiDocumentGeneratorTests/Output/AnnotationInvalidUri.json
+++ b/test/Microsoft.OpenApi.CSharpAnnotations.DocumentGeneration.Tests/OpenApiDocumentGeneratorTests/Output/AnnotationInvalidUri.json
@@ -567,8 +567,7 @@
             "items": {
               "$ref": "#/components/schemas/Microsoft.OpenApi.CSharpAnnotations.DocumentGeneration.Tests.Contracts.SampleObject1"
             },
-            "description": "Gets the sample property object list",
-            "readOnly": true
+            "description": "Gets the sample property object list"
           }
         }
       },
@@ -597,16 +596,14 @@
             "additionalProperties": {
               "$ref": "#/components/schemas/Microsoft.OpenApi.CSharpAnnotations.DocumentGeneration.Tests.Contracts.SampleObject1"
             },
-            "description": "Gets the sample property object dictionary",
-            "readOnly": true
+            "description": "Gets the sample property object dictionary"
           },
           "samplePropertyObjectList": {
             "type": "array",
             "items": {
               "$ref": "#/components/schemas/Microsoft.OpenApi.CSharpAnnotations.DocumentGeneration.Tests.Contracts.SampleObject1"
             },
-            "description": "Gets the sample property object list",
-            "readOnly": true
+            "description": "Gets the sample property object list"
           },
           "samplePropertyString1": {
             "type": "string",

--- a/test/Microsoft.OpenApi.CSharpAnnotations.DocumentGeneration.Tests/OpenApiDocumentGeneratorTests/Output/AnnotationInvalidVerb.json
+++ b/test/Microsoft.OpenApi.CSharpAnnotations.DocumentGeneration.Tests/OpenApiDocumentGeneratorTests/Output/AnnotationInvalidVerb.json
@@ -567,8 +567,7 @@
             "items": {
               "$ref": "#/components/schemas/Microsoft.OpenApi.CSharpAnnotations.DocumentGeneration.Tests.Contracts.SampleObject1"
             },
-            "description": "Gets the sample property object list",
-            "readOnly": true
+            "description": "Gets the sample property object list"
           }
         }
       },
@@ -597,16 +596,14 @@
             "additionalProperties": {
               "$ref": "#/components/schemas/Microsoft.OpenApi.CSharpAnnotations.DocumentGeneration.Tests.Contracts.SampleObject1"
             },
-            "description": "Gets the sample property object dictionary",
-            "readOnly": true
+            "description": "Gets the sample property object dictionary"
           },
           "samplePropertyObjectList": {
             "type": "array",
             "items": {
               "$ref": "#/components/schemas/Microsoft.OpenApi.CSharpAnnotations.DocumentGeneration.Tests.Contracts.SampleObject1"
             },
-            "description": "Gets the sample property object list",
-            "readOnly": true
+            "description": "Gets the sample property object list"
           },
           "samplePropertyString1": {
             "type": "string",

--- a/test/Microsoft.OpenApi.CSharpAnnotations.DocumentGeneration.Tests/OpenApiDocumentGeneratorTests/Output/AnnotationMultipleRequestMediaTypes.Json
+++ b/test/Microsoft.OpenApi.CSharpAnnotations.DocumentGeneration.Tests/OpenApiDocumentGeneratorTests/Output/AnnotationMultipleRequestMediaTypes.Json
@@ -708,8 +708,7 @@
             "items": {
               "$ref": "#/components/schemas/Microsoft.OpenApi.CSharpAnnotations.DocumentGeneration.Tests.Contracts.SampleObject1"
             },
-            "description": "Gets the sample property object list",
-            "readOnly": true
+            "description": "Gets the sample property object list"
           }
         }
       },
@@ -738,16 +737,14 @@
             "additionalProperties": {
               "$ref": "#/components/schemas/Microsoft.OpenApi.CSharpAnnotations.DocumentGeneration.Tests.Contracts.SampleObject1"
             },
-            "description": "Gets the sample property object dictionary",
-            "readOnly": true
+            "description": "Gets the sample property object dictionary"
           },
           "samplePropertyObjectList": {
             "type": "array",
             "items": {
               "$ref": "#/components/schemas/Microsoft.OpenApi.CSharpAnnotations.DocumentGeneration.Tests.Contracts.SampleObject1"
             },
-            "description": "Gets the sample property object list",
-            "readOnly": true
+            "description": "Gets the sample property object list"
           },
           "samplePropertyString1": {
             "type": "string",

--- a/test/Microsoft.OpenApi.CSharpAnnotations.DocumentGeneration.Tests/OpenApiDocumentGeneratorTests/Output/AnnotationMultipleRequestTypes.Json
+++ b/test/Microsoft.OpenApi.CSharpAnnotations.DocumentGeneration.Tests/OpenApiDocumentGeneratorTests/Output/AnnotationMultipleRequestTypes.Json
@@ -694,8 +694,7 @@
             "items": {
               "$ref": "#/components/schemas/Microsoft.OpenApi.CSharpAnnotations.DocumentGeneration.Tests.Contracts.SampleObject1"
             },
-            "description": "Gets the sample property object list",
-            "readOnly": true
+            "description": "Gets the sample property object list"
           }
         }
       },
@@ -724,16 +723,14 @@
             "additionalProperties": {
               "$ref": "#/components/schemas/Microsoft.OpenApi.CSharpAnnotations.DocumentGeneration.Tests.Contracts.SampleObject1"
             },
-            "description": "Gets the sample property object dictionary",
-            "readOnly": true
+            "description": "Gets the sample property object dictionary"
           },
           "samplePropertyObjectList": {
             "type": "array",
             "items": {
               "$ref": "#/components/schemas/Microsoft.OpenApi.CSharpAnnotations.DocumentGeneration.Tests.Contracts.SampleObject1"
             },
-            "description": "Gets the sample property object list",
-            "readOnly": true
+            "description": "Gets the sample property object list"
           },
           "samplePropertyString1": {
             "type": "string",

--- a/test/Microsoft.OpenApi.CSharpAnnotations.DocumentGeneration.Tests/OpenApiDocumentGeneratorTests/Output/AnnotationMultipleResponseMediaTypes.Json
+++ b/test/Microsoft.OpenApi.CSharpAnnotations.DocumentGeneration.Tests/OpenApiDocumentGeneratorTests/Output/AnnotationMultipleResponseMediaTypes.Json
@@ -736,16 +736,14 @@
             "additionalProperties": {
               "$ref": "#/components/schemas/Microsoft.OpenApi.CSharpAnnotations.DocumentGeneration.Tests.Contracts.SampleObject1"
             },
-            "description": "Gets the sample property object dictionary",
-            "readOnly": true
+            "description": "Gets the sample property object dictionary"
           },
           "samplePropertyObjectList": {
             "type": "array",
             "items": {
               "$ref": "#/components/schemas/Microsoft.OpenApi.CSharpAnnotations.DocumentGeneration.Tests.Contracts.SampleObject1"
             },
-            "description": "Gets the sample property object list",
-            "readOnly": true
+            "description": "Gets the sample property object list"
           },
           "samplePropertyString1": {
             "type": "string",
@@ -767,8 +765,7 @@
             "items": {
               "$ref": "#/components/schemas/Microsoft.OpenApi.CSharpAnnotations.DocumentGeneration.Tests.Contracts.SampleObject1"
             },
-            "description": "Gets the sample property object list",
-            "readOnly": true
+            "description": "Gets the sample property object list"
           }
         }
       },

--- a/test/Microsoft.OpenApi.CSharpAnnotations.DocumentGeneration.Tests/OpenApiDocumentGeneratorTests/Output/AnnotationMultipleResponseTypes.Json
+++ b/test/Microsoft.OpenApi.CSharpAnnotations.DocumentGeneration.Tests/OpenApiDocumentGeneratorTests/Output/AnnotationMultipleResponseTypes.Json
@@ -705,16 +705,14 @@
             "additionalProperties": {
               "$ref": "#/components/schemas/Microsoft.OpenApi.CSharpAnnotations.DocumentGeneration.Tests.Contracts.SampleObject1"
             },
-            "description": "Gets the sample property object dictionary",
-            "readOnly": true
+            "description": "Gets the sample property object dictionary"
           },
           "samplePropertyObjectList": {
             "type": "array",
             "items": {
               "$ref": "#/components/schemas/Microsoft.OpenApi.CSharpAnnotations.DocumentGeneration.Tests.Contracts.SampleObject1"
             },
-            "description": "Gets the sample property object list",
-            "readOnly": true
+            "description": "Gets the sample property object list"
           },
           "samplePropertyString1": {
             "type": "string",
@@ -736,8 +734,7 @@
             "items": {
               "$ref": "#/components/schemas/Microsoft.OpenApi.CSharpAnnotations.DocumentGeneration.Tests.Contracts.SampleObject1"
             },
-            "description": "Gets the sample property object list",
-            "readOnly": true
+            "description": "Gets the sample property object list"
           }
         }
       },

--- a/test/Microsoft.OpenApi.CSharpAnnotations.DocumentGeneration.Tests/OpenApiDocumentGeneratorTests/Output/AnnotationNewFilter.Json
+++ b/test/Microsoft.OpenApi.CSharpAnnotations.DocumentGeneration.Tests/OpenApiDocumentGeneratorTests/Output/AnnotationNewFilter.Json
@@ -151,8 +151,7 @@
             "items": {
               "$ref": "#/components/schemas/Microsoft.OpenApi.CSharpAnnotations.DocumentGeneration.Tests.Contracts.SampleObject1"
             },
-            "description": "Gets the sample property object list",
-            "readOnly": true
+            "description": "Gets the sample property object list"
           }
         }
       },
@@ -181,16 +180,14 @@
             "additionalProperties": {
               "$ref": "#/components/schemas/Microsoft.OpenApi.CSharpAnnotations.DocumentGeneration.Tests.Contracts.SampleObject1"
             },
-            "description": "Gets the sample property object dictionary",
-            "readOnly": true
+            "description": "Gets the sample property object dictionary"
           },
           "samplePropertyObjectList": {
             "type": "array",
             "items": {
               "$ref": "#/components/schemas/Microsoft.OpenApi.CSharpAnnotations.DocumentGeneration.Tests.Contracts.SampleObject1"
             },
-            "description": "Gets the sample property object list",
-            "readOnly": true
+            "description": "Gets the sample property object list"
           },
           "samplePropertyString1": {
             "type": "string",
@@ -212,8 +209,7 @@
             "items": {
               "$ref": "#/components/schemas/Microsoft.OpenApi.CSharpAnnotations.DocumentGeneration.Tests.Contracts.SampleObject1"
             },
-            "description": "Gets the sample property object list",
-            "readOnly": true
+            "description": "Gets the sample property object list"
           }
         }
       }

--- a/test/Microsoft.OpenApi.CSharpAnnotations.DocumentGeneration.Tests/OpenApiDocumentGeneratorTests/Output/AnnotationOptionalPathParametersBranching.Json
+++ b/test/Microsoft.OpenApi.CSharpAnnotations.DocumentGeneration.Tests/OpenApiDocumentGeneratorTests/Output/AnnotationOptionalPathParametersBranching.Json
@@ -1456,8 +1456,7 @@
             "items": {
               "$ref": "#/components/schemas/Microsoft.OpenApi.CSharpAnnotations.DocumentGeneration.Tests.Contracts.SampleObject1"
             },
-            "description": "Gets the sample property object list",
-            "readOnly": true
+            "description": "Gets the sample property object list"
           }
         }
       },
@@ -1486,16 +1485,14 @@
             "additionalProperties": {
               "$ref": "#/components/schemas/Microsoft.OpenApi.CSharpAnnotations.DocumentGeneration.Tests.Contracts.SampleObject1"
             },
-            "description": "Gets the sample property object dictionary",
-            "readOnly": true
+            "description": "Gets the sample property object dictionary"
           },
           "samplePropertyObjectList": {
             "type": "array",
             "items": {
               "$ref": "#/components/schemas/Microsoft.OpenApi.CSharpAnnotations.DocumentGeneration.Tests.Contracts.SampleObject1"
             },
-            "description": "Gets the sample property object list",
-            "readOnly": true
+            "description": "Gets the sample property object list"
           },
           "samplePropertyString1": {
             "type": "string",

--- a/test/Microsoft.OpenApi.CSharpAnnotations.DocumentGeneration.Tests/OpenApiDocumentGeneratorTests/Output/AnnotationParamNoTypeSpecified.json
+++ b/test/Microsoft.OpenApi.CSharpAnnotations.DocumentGeneration.Tests/OpenApiDocumentGeneratorTests/Output/AnnotationParamNoTypeSpecified.json
@@ -684,8 +684,7 @@
             "items": {
               "$ref": "#/components/schemas/Microsoft.OpenApi.CSharpAnnotations.DocumentGeneration.Tests.Contracts.SampleObject1"
             },
-            "description": "Gets the sample property object list",
-            "readOnly": true
+            "description": "Gets the sample property object list"
           }
         }
       },
@@ -714,16 +713,14 @@
             "additionalProperties": {
               "$ref": "#/components/schemas/Microsoft.OpenApi.CSharpAnnotations.DocumentGeneration.Tests.Contracts.SampleObject1"
             },
-            "description": "Gets the sample property object dictionary",
-            "readOnly": true
+            "description": "Gets the sample property object dictionary"
           },
           "samplePropertyObjectList": {
             "type": "array",
             "items": {
               "$ref": "#/components/schemas/Microsoft.OpenApi.CSharpAnnotations.DocumentGeneration.Tests.Contracts.SampleObject1"
             },
-            "description": "Gets the sample property object list",
-            "readOnly": true
+            "description": "Gets the sample property object list"
           },
           "samplePropertyString1": {
             "type": "string",

--- a/test/Microsoft.OpenApi.CSharpAnnotations.DocumentGeneration.Tests/OpenApiDocumentGeneratorTests/Output/AnnotationParamWithoutInButPresentInUrl.Json
+++ b/test/Microsoft.OpenApi.CSharpAnnotations.DocumentGeneration.Tests/OpenApiDocumentGeneratorTests/Output/AnnotationParamWithoutInButPresentInUrl.Json
@@ -684,8 +684,7 @@
             "items": {
               "$ref": "#/components/schemas/Microsoft.OpenApi.CSharpAnnotations.DocumentGeneration.Tests.Contracts.SampleObject1"
             },
-            "description": "Gets the sample property object list",
-            "readOnly": true
+            "description": "Gets the sample property object list"
           }
         }
       },
@@ -714,16 +713,14 @@
             "additionalProperties": {
               "$ref": "#/components/schemas/Microsoft.OpenApi.CSharpAnnotations.DocumentGeneration.Tests.Contracts.SampleObject1"
             },
-            "description": "Gets the sample property object dictionary",
-            "readOnly": true
+            "description": "Gets the sample property object dictionary"
           },
           "samplePropertyObjectList": {
             "type": "array",
             "items": {
               "$ref": "#/components/schemas/Microsoft.OpenApi.CSharpAnnotations.DocumentGeneration.Tests.Contracts.SampleObject1"
             },
-            "description": "Gets the sample property object list",
-            "readOnly": true
+            "description": "Gets the sample property object list"
           },
           "samplePropertyString1": {
             "type": "string",

--- a/test/Microsoft.OpenApi.CSharpAnnotations.DocumentGeneration.Tests/OpenApiDocumentGeneratorTests/Output/AnnotationParamWithoutInNotPresentInUrl.Json
+++ b/test/Microsoft.OpenApi.CSharpAnnotations.DocumentGeneration.Tests/OpenApiDocumentGeneratorTests/Output/AnnotationParamWithoutInNotPresentInUrl.Json
@@ -610,8 +610,7 @@
             "items": {
               "$ref": "#/components/schemas/Microsoft.OpenApi.CSharpAnnotations.DocumentGeneration.Tests.Contracts.SampleObject1"
             },
-            "description": "Gets the sample property object list",
-            "readOnly": true
+            "description": "Gets the sample property object list"
           }
         }
       },
@@ -640,16 +639,14 @@
             "additionalProperties": {
               "$ref": "#/components/schemas/Microsoft.OpenApi.CSharpAnnotations.DocumentGeneration.Tests.Contracts.SampleObject1"
             },
-            "description": "Gets the sample property object dictionary",
-            "readOnly": true
+            "description": "Gets the sample property object dictionary"
           },
           "samplePropertyObjectList": {
             "type": "array",
             "items": {
               "$ref": "#/components/schemas/Microsoft.OpenApi.CSharpAnnotations.DocumentGeneration.Tests.Contracts.SampleObject1"
             },
-            "description": "Gets the sample property object list",
-            "readOnly": true
+            "description": "Gets the sample property object list"
           },
           "samplePropertyString1": {
             "type": "string",

--- a/test/Microsoft.OpenApi.CSharpAnnotations.DocumentGeneration.Tests/OpenApiDocumentGeneratorTests/Output/AnnotationRequestMissingSeeTag.json
+++ b/test/Microsoft.OpenApi.CSharpAnnotations.DocumentGeneration.Tests/OpenApiDocumentGeneratorTests/Output/AnnotationRequestMissingSeeTag.json
@@ -609,8 +609,7 @@
             "items": {
               "$ref": "#/components/schemas/Microsoft.OpenApi.CSharpAnnotations.DocumentGeneration.Tests.Contracts.SampleObject1"
             },
-            "description": "Gets the sample property object list",
-            "readOnly": true
+            "description": "Gets the sample property object list"
           }
         }
       },
@@ -639,16 +638,14 @@
             "additionalProperties": {
               "$ref": "#/components/schemas/Microsoft.OpenApi.CSharpAnnotations.DocumentGeneration.Tests.Contracts.SampleObject1"
             },
-            "description": "Gets the sample property object dictionary",
-            "readOnly": true
+            "description": "Gets the sample property object dictionary"
           },
           "samplePropertyObjectList": {
             "type": "array",
             "items": {
               "$ref": "#/components/schemas/Microsoft.OpenApi.CSharpAnnotations.DocumentGeneration.Tests.Contracts.SampleObject1"
             },
-            "description": "Gets the sample property object list",
-            "readOnly": true
+            "description": "Gets the sample property object list"
           },
           "samplePropertyString1": {
             "type": "string",

--- a/test/Microsoft.OpenApi.CSharpAnnotations.DocumentGeneration.Tests/OpenApiDocumentGeneratorTests/Output/AnnotationSummaryWithTags.Json
+++ b/test/Microsoft.OpenApi.CSharpAnnotations.DocumentGeneration.Tests/OpenApiDocumentGeneratorTests/Output/AnnotationSummaryWithTags.Json
@@ -684,8 +684,7 @@
             "items": {
               "$ref": "#/components/schemas/Microsoft.OpenApi.CSharpAnnotations.DocumentGeneration.Tests.Contracts.SampleObject1"
             },
-            "description": "Gets the sample property object list",
-            "readOnly": true
+            "description": "Gets the sample property object list"
           }
         }
       },
@@ -714,16 +713,14 @@
             "additionalProperties": {
               "$ref": "#/components/schemas/Microsoft.OpenApi.CSharpAnnotations.DocumentGeneration.Tests.Contracts.SampleObject1"
             },
-            "description": "Gets the sample property object dictionary",
-            "readOnly": true
+            "description": "Gets the sample property object dictionary"
           },
           "samplePropertyObjectList": {
             "type": "array",
             "items": {
               "$ref": "#/components/schemas/Microsoft.OpenApi.CSharpAnnotations.DocumentGeneration.Tests.Contracts.SampleObject1"
             },
-            "description": "Gets the sample property object list",
-            "readOnly": true
+            "description": "Gets the sample property object list"
           },
           "samplePropertyString1": {
             "type": "string",

--- a/test/Microsoft.OpenApi.CSharpAnnotations.DocumentGeneration.Tests/OpenApiDocumentGeneratorTests/Output/AnnotationTypeNotFound.json
+++ b/test/Microsoft.OpenApi.CSharpAnnotations.DocumentGeneration.Tests/OpenApiDocumentGeneratorTests/Output/AnnotationTypeNotFound.json
@@ -609,8 +609,7 @@
             "items": {
               "$ref": "#/components/schemas/Microsoft.OpenApi.CSharpAnnotations.DocumentGeneration.Tests.Contracts.SampleObject1"
             },
-            "description": "Gets the sample property object list",
-            "readOnly": true
+            "description": "Gets the sample property object list"
           }
         }
       },
@@ -639,16 +638,14 @@
             "additionalProperties": {
               "$ref": "#/components/schemas/Microsoft.OpenApi.CSharpAnnotations.DocumentGeneration.Tests.Contracts.SampleObject1"
             },
-            "description": "Gets the sample property object dictionary",
-            "readOnly": true
+            "description": "Gets the sample property object dictionary"
           },
           "samplePropertyObjectList": {
             "type": "array",
             "items": {
               "$ref": "#/components/schemas/Microsoft.OpenApi.CSharpAnnotations.DocumentGeneration.Tests.Contracts.SampleObject1"
             },
-            "description": "Gets the sample property object list",
-            "readOnly": true
+            "description": "Gets the sample property object list"
           },
           "samplePropertyString1": {
             "type": "string",

--- a/test/Microsoft.OpenApi.CSharpAnnotations.DocumentGeneration.Tests/OpenApiDocumentGeneratorTests/Output/AnnotationUndocumentedGeneric.json
+++ b/test/Microsoft.OpenApi.CSharpAnnotations.DocumentGeneration.Tests/OpenApiDocumentGeneratorTests/Output/AnnotationUndocumentedGeneric.json
@@ -609,8 +609,7 @@
             "items": {
               "$ref": "#/components/schemas/Microsoft.OpenApi.CSharpAnnotations.DocumentGeneration.Tests.Contracts.SampleObject1"
             },
-            "description": "Gets the sample property object list",
-            "readOnly": true
+            "description": "Gets the sample property object list"
           }
         }
       },
@@ -639,16 +638,14 @@
             "additionalProperties": {
               "$ref": "#/components/schemas/Microsoft.OpenApi.CSharpAnnotations.DocumentGeneration.Tests.Contracts.SampleObject1"
             },
-            "description": "Gets the sample property object dictionary",
-            "readOnly": true
+            "description": "Gets the sample property object dictionary"
           },
           "samplePropertyObjectList": {
             "type": "array",
             "items": {
               "$ref": "#/components/schemas/Microsoft.OpenApi.CSharpAnnotations.DocumentGeneration.Tests.Contracts.SampleObject1"
             },
-            "description": "Gets the sample property object list",
-            "readOnly": true
+            "description": "Gets the sample property object list"
           },
           "samplePropertyString1": {
             "type": "string",

--- a/test/Microsoft.OpenApi.CSharpAnnotations.DocumentGeneration.Tests/OpenApiDocumentGeneratorTests/Output/AnnotationUndocumentedPathParam.Json
+++ b/test/Microsoft.OpenApi.CSharpAnnotations.DocumentGeneration.Tests/OpenApiDocumentGeneratorTests/Output/AnnotationUndocumentedPathParam.Json
@@ -610,8 +610,7 @@
             "items": {
               "$ref": "#/components/schemas/Microsoft.OpenApi.CSharpAnnotations.DocumentGeneration.Tests.Contracts.SampleObject1"
             },
-            "description": "Gets the sample property object list",
-            "readOnly": true
+            "description": "Gets the sample property object list"
           }
         }
       },
@@ -640,16 +639,14 @@
             "additionalProperties": {
               "$ref": "#/components/schemas/Microsoft.OpenApi.CSharpAnnotations.DocumentGeneration.Tests.Contracts.SampleObject1"
             },
-            "description": "Gets the sample property object dictionary",
-            "readOnly": true
+            "description": "Gets the sample property object dictionary"
           },
           "samplePropertyObjectList": {
             "type": "array",
             "items": {
               "$ref": "#/components/schemas/Microsoft.OpenApi.CSharpAnnotations.DocumentGeneration.Tests.Contracts.SampleObject1"
             },
-            "description": "Gets the sample property object list",
-            "readOnly": true
+            "description": "Gets the sample property object list"
           },
           "samplePropertyString1": {
             "type": "string",

--- a/test/Microsoft.OpenApi.CSharpAnnotations.DocumentGeneration.Tests/OperationConfigTests/Output/AnnotationApplyToAllOperations.json
+++ b/test/Microsoft.OpenApi.CSharpAnnotations.DocumentGeneration.Tests/OperationConfigTests/Output/AnnotationApplyToAllOperations.json
@@ -667,8 +667,7 @@
             "items": {
               "$ref": "#/components/schemas/Microsoft.OpenApi.CSharpAnnotations.DocumentGeneration.Tests.Contracts.SampleObject1"
             },
-            "description": "Gets the sample property object list",
-            "readOnly": true
+            "description": "Gets the sample property object list"
           }
         }
       },
@@ -697,16 +696,14 @@
             "additionalProperties": {
               "$ref": "#/components/schemas/Microsoft.OpenApi.CSharpAnnotations.DocumentGeneration.Tests.Contracts.SampleObject1"
             },
-            "description": "Gets the sample property object dictionary",
-            "readOnly": true
+            "description": "Gets the sample property object dictionary"
           },
           "samplePropertyObjectList": {
             "type": "array",
             "items": {
               "$ref": "#/components/schemas/Microsoft.OpenApi.CSharpAnnotations.DocumentGeneration.Tests.Contracts.SampleObject1"
             },
-            "description": "Gets the sample property object list",
-            "readOnly": true
+            "description": "Gets the sample property object list"
           },
           "samplePropertyString1": {
             "type": "string",

--- a/test/Microsoft.OpenApi.CSharpAnnotations.DocumentGeneration.Tests/OperationConfigTests/Output/AnnotationApplyToSomeOperations.json
+++ b/test/Microsoft.OpenApi.CSharpAnnotations.DocumentGeneration.Tests/OperationConfigTests/Output/AnnotationApplyToSomeOperations.json
@@ -663,8 +663,7 @@
             "items": {
               "$ref": "#/components/schemas/Microsoft.OpenApi.CSharpAnnotations.DocumentGeneration.Tests.Contracts.SampleObject1"
             },
-            "description": "Gets the sample property object list",
-            "readOnly": true
+            "description": "Gets the sample property object list"
           }
         }
       },
@@ -693,16 +692,14 @@
             "additionalProperties": {
               "$ref": "#/components/schemas/Microsoft.OpenApi.CSharpAnnotations.DocumentGeneration.Tests.Contracts.SampleObject1"
             },
-            "description": "Gets the sample property object dictionary",
-            "readOnly": true
+            "description": "Gets the sample property object dictionary"
           },
           "samplePropertyObjectList": {
             "type": "array",
             "items": {
               "$ref": "#/components/schemas/Microsoft.OpenApi.CSharpAnnotations.DocumentGeneration.Tests.Contracts.SampleObject1"
             },
-            "description": "Gets the sample property object list",
-            "readOnly": true
+            "description": "Gets the sample property object list"
           },
           "samplePropertyString1": {
             "type": "string",

--- a/test/Microsoft.OpenApi.CSharpAnnotations.DocumentGeneration.Tests/OperationConfigTests/Output/AnnotationBlankOperationConfig.json
+++ b/test/Microsoft.OpenApi.CSharpAnnotations.DocumentGeneration.Tests/OperationConfigTests/Output/AnnotationBlankOperationConfig.json
@@ -548,8 +548,7 @@
             "items": {
               "$ref": "#/components/schemas/Microsoft.OpenApi.CSharpAnnotations.DocumentGeneration.Tests.Contracts.SampleObject1"
             },
-            "description": "Gets the sample property object list",
-            "readOnly": true
+            "description": "Gets the sample property object list"
           }
         }
       },
@@ -578,16 +577,14 @@
             "additionalProperties": {
               "$ref": "#/components/schemas/Microsoft.OpenApi.CSharpAnnotations.DocumentGeneration.Tests.Contracts.SampleObject1"
             },
-            "description": "Gets the sample property object dictionary",
-            "readOnly": true
+            "description": "Gets the sample property object dictionary"
           },
           "samplePropertyObjectList": {
             "type": "array",
             "items": {
               "$ref": "#/components/schemas/Microsoft.OpenApi.CSharpAnnotations.DocumentGeneration.Tests.Contracts.SampleObject1"
             },
-            "description": "Gets the sample property object list",
-            "readOnly": true
+            "description": "Gets the sample property object list"
           },
           "samplePropertyString1": {
             "type": "string",

--- a/test/Microsoft.OpenApi.CSharpAnnotations.DocumentGeneration.Tests/OperationConfigTests/Output/AnnotationNoOperationConfig.json
+++ b/test/Microsoft.OpenApi.CSharpAnnotations.DocumentGeneration.Tests/OperationConfigTests/Output/AnnotationNoOperationConfig.json
@@ -548,8 +548,7 @@
             "items": {
               "$ref": "#/components/schemas/Microsoft.OpenApi.CSharpAnnotations.DocumentGeneration.Tests.Contracts.SampleObject1"
             },
-            "description": "Gets the sample property object list",
-            "readOnly": true
+            "description": "Gets the sample property object list"
           }
         }
       },
@@ -578,16 +577,14 @@
             "additionalProperties": {
               "$ref": "#/components/schemas/Microsoft.OpenApi.CSharpAnnotations.DocumentGeneration.Tests.Contracts.SampleObject1"
             },
-            "description": "Gets the sample property object dictionary",
-            "readOnly": true
+            "description": "Gets the sample property object dictionary"
           },
           "samplePropertyObjectList": {
             "type": "array",
             "items": {
               "$ref": "#/components/schemas/Microsoft.OpenApi.CSharpAnnotations.DocumentGeneration.Tests.Contracts.SampleObject1"
             },
-            "description": "Gets the sample property object list",
-            "readOnly": true
+            "description": "Gets the sample property object list"
           },
           "samplePropertyString1": {
             "type": "string",

--- a/test/Microsoft.OpenApi.CSharpAnnotations.DocumentGeneration.Tests/OperationConfigTests/Output/AnnotationOverridden.json
+++ b/test/Microsoft.OpenApi.CSharpAnnotations.DocumentGeneration.Tests/OperationConfigTests/Output/AnnotationOverridden.json
@@ -548,8 +548,7 @@
             "items": {
               "$ref": "#/components/schemas/Microsoft.OpenApi.CSharpAnnotations.DocumentGeneration.Tests.Contracts.SampleObject1"
             },
-            "description": "Gets the sample property object list",
-            "readOnly": true
+            "description": "Gets the sample property object list"
           }
         }
       },
@@ -578,16 +577,14 @@
             "additionalProperties": {
               "$ref": "#/components/schemas/Microsoft.OpenApi.CSharpAnnotations.DocumentGeneration.Tests.Contracts.SampleObject1"
             },
-            "description": "Gets the sample property object dictionary",
-            "readOnly": true
+            "description": "Gets the sample property object dictionary"
           },
           "samplePropertyObjectList": {
             "type": "array",
             "items": {
               "$ref": "#/components/schemas/Microsoft.OpenApi.CSharpAnnotations.DocumentGeneration.Tests.Contracts.SampleObject1"
             },
-            "description": "Gets the sample property object list",
-            "readOnly": true
+            "description": "Gets the sample property object list"
           },
           "samplePropertyString1": {
             "type": "string",

--- a/test/Microsoft.OpenApi.CSharpAnnotations.DocumentGeneration.Tests/ReferenceRegistryTests/ReferenceRegistryTest.cs
+++ b/test/Microsoft.OpenApi.CSharpAnnotations.DocumentGeneration.Tests/ReferenceRegistryTests/ReferenceRegistryTest.cs
@@ -470,6 +470,26 @@ namespace Microsoft.OpenApi.CSharpAnnotations.DocumentGeneration.Tests.Reference
                     = SampleBaseType2.schema
                 }
             };
+
+            //Type with JObject Attribute
+            yield return new object[]
+            {
+                typeof(SampleTypeWithJObjectAttribute),
+                new OpenApiSchema
+                {
+                    Reference = new OpenApiReference
+                    {
+                        Type = ReferenceType.Schema,
+                        Id = typeof(SampleTypeWithJObjectAttribute).ToString().SanitizeClassName()
+                    }
+                },
+                new Dictionary<string, OpenApiSchema>
+                {
+                    [typeof(SampleTypeWithJObjectAttribute).ToString().SanitizeClassName()]
+                    = SampleTypeWithJObjectAttribute.schema
+                }
+            };
+
         }
     }
 }

--- a/test/Microsoft.OpenApi.CSharpAnnotations.DocumentGeneration.Tests/ReferenceRegistryTests/Types/SampleBaseType1.cs
+++ b/test/Microsoft.OpenApi.CSharpAnnotations.DocumentGeneration.Tests/ReferenceRegistryTests/Types/SampleBaseType1.cs
@@ -20,7 +20,6 @@ namespace Microsoft.OpenApi.CSharpAnnotations.DocumentGeneration.Tests.Reference
                 ["sampleList"] = new OpenApiSchema
                 {
                     Type = "array",
-                    ReadOnly = true,
                     Items = new OpenApiSchema
                     {
                         Reference = new OpenApiReference
@@ -33,7 +32,6 @@ namespace Microsoft.OpenApi.CSharpAnnotations.DocumentGeneration.Tests.Reference
                 ["SampleStringList"] = new OpenApiSchema
                 {
                     Type = "array",
-                    ReadOnly = true,
                     Items = new OpenApiSchema
                     {
                         Type = "string"
@@ -42,7 +40,6 @@ namespace Microsoft.OpenApi.CSharpAnnotations.DocumentGeneration.Tests.Reference
                 ["SampleList2"] = new OpenApiSchema
                 {
                     Type = "array",
-                    ReadOnly = true,
                     Items = new OpenApiSchema
                     {
                         Reference = new OpenApiReference

--- a/test/Microsoft.OpenApi.CSharpAnnotations.DocumentGeneration.Tests/ReferenceRegistryTests/Types/SampleBaseType2.cs
+++ b/test/Microsoft.OpenApi.CSharpAnnotations.DocumentGeneration.Tests/ReferenceRegistryTests/Types/SampleBaseType2.cs
@@ -19,7 +19,6 @@ namespace Microsoft.OpenApi.CSharpAnnotations.DocumentGeneration.Tests.Reference
                 ["sampleList"] = new OpenApiSchema
                 {
                     Type = "array",
-                    ReadOnly = true,
                     Items = new OpenApiSchema
                     {
                         Type = "string"
@@ -28,7 +27,6 @@ namespace Microsoft.OpenApi.CSharpAnnotations.DocumentGeneration.Tests.Reference
                 ["SampleList2"] = new OpenApiSchema
                 {
                     Type = "array",
-                    ReadOnly = true,
                     Items = new OpenApiSchema
                     {
                         Type = "integer",

--- a/test/Microsoft.OpenApi.CSharpAnnotations.DocumentGeneration.Tests/ReferenceRegistryTests/Types/SampleChildType1.cs
+++ b/test/Microsoft.OpenApi.CSharpAnnotations.DocumentGeneration.Tests/ReferenceRegistryTests/Types/SampleChildType1.cs
@@ -20,7 +20,6 @@ namespace Microsoft.OpenApi.CSharpAnnotations.DocumentGeneration.Tests.Reference
                 ["sampleList"] = new OpenApiSchema
                 {
                     Type = "array",
-                    ReadOnly = true,
                     Items = new OpenApiSchema
                     {
                         Reference = new OpenApiReference
@@ -33,7 +32,6 @@ namespace Microsoft.OpenApi.CSharpAnnotations.DocumentGeneration.Tests.Reference
                 ["SampleStringList"] = new OpenApiSchema
                 {
                     Type = "array",
-                    ReadOnly = true,
                     Items = new OpenApiSchema
                     {
                         Type = "string"
@@ -42,7 +40,6 @@ namespace Microsoft.OpenApi.CSharpAnnotations.DocumentGeneration.Tests.Reference
                 ["SampleList2"] = new OpenApiSchema
                 {
                     Type = "array",
-                    ReadOnly = true,
                     Items = new OpenApiSchema
                     {
                         Reference = new OpenApiReference
@@ -54,7 +51,6 @@ namespace Microsoft.OpenApi.CSharpAnnotations.DocumentGeneration.Tests.Reference
                 },
                 ["SampleProperty"] = new OpenApiSchema
                 {
-                    ReadOnly = true,
                     Type = "string"
                 }
             }

--- a/test/Microsoft.OpenApi.CSharpAnnotations.DocumentGeneration.Tests/ReferenceRegistryTests/Types/SampleChildType2.cs
+++ b/test/Microsoft.OpenApi.CSharpAnnotations.DocumentGeneration.Tests/ReferenceRegistryTests/Types/SampleChildType2.cs
@@ -19,7 +19,6 @@ namespace Microsoft.OpenApi.CSharpAnnotations.DocumentGeneration.Tests.Reference
                 ["sampleList"] = new OpenApiSchema
                 {
                     Type = "array",
-                    ReadOnly = true,
                     Items = new OpenApiSchema
                     {
                         Type = "integer",
@@ -29,7 +28,6 @@ namespace Microsoft.OpenApi.CSharpAnnotations.DocumentGeneration.Tests.Reference
                 ["SampleList2"] = new OpenApiSchema
                 {
                     Type = "array",
-                    ReadOnly = true,
                     Items = new OpenApiSchema
                     {
                         Type = "string"

--- a/test/Microsoft.OpenApi.CSharpAnnotations.DocumentGeneration.Tests/ReferenceRegistryTests/Types/SampleInnerType.cs
+++ b/test/Microsoft.OpenApi.CSharpAnnotations.DocumentGeneration.Tests/ReferenceRegistryTests/Types/SampleInnerType.cs
@@ -20,7 +20,6 @@ namespace Microsoft.OpenApi.CSharpAnnotations.DocumentGeneration.Tests.Reference
                 ["SamplePropertyInnerEnum"] = new OpenApiSchema
                 {
                     Type = "string",
-                    ReadOnly = false,
                     Enum = new List<IOpenApiAny>
                     {
                         new OpenApiString(SampleEnum.SampleEnumValueFirst.ToString()),
@@ -30,7 +29,6 @@ namespace Microsoft.OpenApi.CSharpAnnotations.DocumentGeneration.Tests.Reference
                 ["SamplePropertyInnerListInt"] = new OpenApiSchema
                 {
                     Type = "array",
-                    ReadOnly = true,
                     Items = new OpenApiSchema
                     {
                         Type = "integer",
@@ -39,8 +37,7 @@ namespace Microsoft.OpenApi.CSharpAnnotations.DocumentGeneration.Tests.Reference
                 },
                 ["SamplePropertyInnerString"] = new OpenApiSchema
                 {
-                    Type = "string",
-                    ReadOnly = false
+                    Type = "string"
                 }
             }
         };

--- a/test/Microsoft.OpenApi.CSharpAnnotations.DocumentGeneration.Tests/ReferenceRegistryTests/Types/SampleType.cs
+++ b/test/Microsoft.OpenApi.CSharpAnnotations.DocumentGeneration.Tests/ReferenceRegistryTests/Types/SampleType.cs
@@ -26,7 +26,6 @@ namespace Microsoft.OpenApi.CSharpAnnotations.DocumentGeneration.Tests.Reference
                 ["SamplePropertyDictionaryStringObject"] = new OpenApiSchema
                 {
                     Type = "object",
-                    ReadOnly = true,
                     AdditionalProperties = new OpenApiSchema
                     {
                         Reference = new OpenApiReference
@@ -39,7 +38,6 @@ namespace Microsoft.OpenApi.CSharpAnnotations.DocumentGeneration.Tests.Reference
                 ["SamplePropertyDictionaryStringString"] = new OpenApiSchema
                 {
                     Type = "object",
-                    ReadOnly = true,
                     AdditionalProperties = new OpenApiSchema
                     {
                         Type = "string"
@@ -48,7 +46,6 @@ namespace Microsoft.OpenApi.CSharpAnnotations.DocumentGeneration.Tests.Reference
                 ["SamplePropertyEnum"] = new OpenApiSchema
                 {
                     Type = "string",
-                    ReadOnly = false,
                     Enum = new List<IOpenApiAny>
                     {
                         new OpenApiString(SampleEnum.SampleEnumValueFirst.ToString()),
@@ -58,7 +55,6 @@ namespace Microsoft.OpenApi.CSharpAnnotations.DocumentGeneration.Tests.Reference
                 ["SamplePropertyIDictionaryStringObject"] = new OpenApiSchema
                 {
                     Type = "object",
-                    ReadOnly = true,
                     AdditionalProperties = new OpenApiSchema
                     {
                         Reference = new OpenApiReference
@@ -71,7 +67,6 @@ namespace Microsoft.OpenApi.CSharpAnnotations.DocumentGeneration.Tests.Reference
                 ["SamplePropertyIDictionaryStringString"] = new OpenApiSchema
                 {
                     Type = "object",
-                    ReadOnly = true,
                     AdditionalProperties = new OpenApiSchema
                     {
                         Type = "string"
@@ -80,7 +75,6 @@ namespace Microsoft.OpenApi.CSharpAnnotations.DocumentGeneration.Tests.Reference
                 ["SamplePropertyIListObject"] = new OpenApiSchema
                 {
                     Type = "array",
-                    ReadOnly = true,
                     Items = new OpenApiSchema
                     {
                         Reference = new OpenApiReference
@@ -93,8 +87,7 @@ namespace Microsoft.OpenApi.CSharpAnnotations.DocumentGeneration.Tests.Reference
                 ["SamplePropertyInt"] = new OpenApiSchema
                 {
                     Type = "integer",
-                    Format = "int32",
-                    ReadOnly = false
+                    Format = "int32"
                 },
                 ["SamplePropertyListEnum"] = new OpenApiSchema
                 {
@@ -107,8 +100,7 @@ namespace Microsoft.OpenApi.CSharpAnnotations.DocumentGeneration.Tests.Reference
                             new OpenApiString(SampleEnum.SampleEnumValueFirst.ToString()),
                             new OpenApiString(SampleEnum.SampleEnumValueSecond.ToString())
                         }
-                    },
-                    ReadOnly = true
+                    }
                 },
                 ["SamplePropertyListObject"] = new OpenApiSchema
                 {
@@ -120,8 +112,7 @@ namespace Microsoft.OpenApi.CSharpAnnotations.DocumentGeneration.Tests.Reference
                             Type = ReferenceType.Schema,
                             Id = typeof(SampleInnerType).ToString().SanitizeClassName()
                         }
-                    },
-                    ReadOnly = true
+                    }
                 },
                 ["SamplePropertyListString"] = new OpenApiSchema
                 {
@@ -129,8 +120,7 @@ namespace Microsoft.OpenApi.CSharpAnnotations.DocumentGeneration.Tests.Reference
                     Items = new OpenApiSchema
                     {
                         Type = "string"
-                    },
-                    ReadOnly = true
+                    }
                 },
                 ["SamplePropertyObject"] = new OpenApiSchema
                 {
@@ -146,8 +136,7 @@ namespace Microsoft.OpenApi.CSharpAnnotations.DocumentGeneration.Tests.Reference
                     {
                         Type = ReferenceType.Schema,
                         Id = typeof(SampleInnerType).ToString().SanitizeClassName()
-                    },
-                    ReadOnly = true
+                    }
                 },
                 ["samplePropertyStringNotRequired"] = new OpenApiSchema
                 {

--- a/test/Microsoft.OpenApi.CSharpAnnotations.DocumentGeneration.Tests/ReferenceRegistryTests/Types/SampleTypeWithJObjectAttribute.cs
+++ b/test/Microsoft.OpenApi.CSharpAnnotations.DocumentGeneration.Tests/ReferenceRegistryTests/Types/SampleTypeWithJObjectAttribute.cs
@@ -1,0 +1,47 @@
+﻿// ------------------------------------------------------------
+//  Copyright (c) Microsoft Corporation.  All rights reserved.
+//  Licensed under the MIT License (MIT). See LICENSE in the repo root for license information.
+// ------------------------------------------------------------
+
+using System.Collections.Generic;
+using Microsoft.OpenApi.Models;
+using Newtonsoft.Json;
+using Newtonsoft.Json.Serialization;
+
+namespace Microsoft.OpenApi.CSharpAnnotations.DocumentGeneration.Tests.ReferenceRegistryTests.Types
+{
+    [JsonObject(NamingStrategyType = typeof(CamelCaseNamingStrategy))]
+    internal class SampleTypeWithJObjectAttribute
+    {
+        public static readonly OpenApiSchema schema = new OpenApiSchema
+        {
+            Type = "object",
+            Required = new HashSet<string>
+            {
+                "samplePropertyStringRequired"
+            },
+            Properties = new Dictionary<string, OpenApiSchema>
+            {
+                ["samplePropertyStringRequired"] = new OpenApiSchema
+                {
+                    Type = "string"
+                },
+                ["sampleProperty"] = new OpenApiSchema
+                {
+                    Type = "string"
+                },
+                ["sampleProperty2"] = new OpenApiSchema
+                {
+                    Type = "string"
+                },
+            }
+        };
+
+        public string SampleProperty { get; set; }
+
+        public string SampleProperty2 { get; set; }
+
+        [JsonProperty(Required = Required.Always)]
+        public string SamplePropertyStringRequired { get; set; }
+    }
+}


### PR DESCRIPTION
- SchemaRegistry Code change to read JObject attribute and populate the naming strategy
- Remove setting readonly when property have only get