### PR TITLE
Code changes to fix the description bug

### DIFF
--- a/src/Microsoft.OpenApi.CSharpAnnotations.DocumentGeneration/Extensions/XElementExtensions.cs
+++ b/src/Microsoft.OpenApi.CSharpAnnotations.DocumentGeneration/Extensions/XElementExtensions.cs
@@ -81,6 +81,25 @@ namespace Microsoft.OpenApi.CSharpAnnotations.DocumentGeneration.Extensions
         }
 
         /// <summary>
+        /// Gets the text from the last text node of the provided element's child nodes with the following modifications:
+        /// 1. Any blank lines are removed.
+        /// 2. Beginning and trailing whitespaces are trimmed.
+        /// </summary>
+        public static string GetDescriptionTextFromLastTextNode(this XElement element)
+        {
+            var lastTextNode = element.Nodes()
+                .Where( i => i.NodeType == XmlNodeType.Text )
+                .LastOrDefault();
+
+            if (lastTextNode != null)
+            {
+                return lastTextNode.ToString().Trim().RemoveBlankLines();
+            }
+
+            return string.Empty;
+        }
+
+        /// <summary>
         /// Fetches list of fully qualified type names from the "cref" attribute or "see" tag of the provided XElement.
         /// </summary>
         /// <param name="xElement">The XElement to process.</param>

--- a/src/Microsoft.OpenApi.CSharpAnnotations.DocumentGeneration/Microsoft.OpenApi.CSharpAnnotations.DocumentGeneration.csproj
+++ b/src/Microsoft.OpenApi.CSharpAnnotations.DocumentGeneration/Microsoft.OpenApi.CSharpAnnotations.DocumentGeneration.csproj
@@ -10,7 +10,7 @@
         <Company>Microsoft</Company>
         <Title>Microsoft.OpenApi.CSharpAnnotations.DocumentGeneration</Title>
         <PackageId>Microsoft.OpenApi.CSharpAnnotations.DocumentGeneration</PackageId>
-        <Version>1.0.0-beta039</Version>
+        <Version>1.0.0-beta040</Version>
         <Description>Library that translates Visual Studio C# Annotations into .NET objects representing OpenAPI specification.</Description>
         <Copyright>© Microsoft Corporation. All rights reserved.</Copyright>
         <PackageTags>Microsoft.OpenApi.CSharpAnnotations.DocumentGeneration</PackageTags>

--- a/src/Microsoft.OpenApi.CSharpAnnotations.DocumentGeneration/OperationFilters/ParamToParameterFilter.cs
+++ b/src/Microsoft.OpenApi.CSharpAnnotations.DocumentGeneration/OperationFilters/ParamToParameterFilter.cs
@@ -64,15 +64,7 @@ namespace Microsoft.OpenApi.CSharpAnnotations.DocumentGeneration.OperationFilter
                 var isRequired = paramElement.Attribute(KnownXmlStrings.Required)?.Value.Trim();
                 var cref = paramElement.Attribute(KnownXmlStrings.Cref)?.Value.Trim();
 
-                var childNodes = paramElement.DescendantNodes().ToList();
-                var description = string.Empty;
-
-                var lastNode = childNodes.LastOrDefault();
-
-                if (lastNode != null && lastNode.NodeType == XmlNodeType.Text)
-                {
-                    description = lastNode.ToString().Trim().RemoveBlankLines();
-                }
+                var description = paramElement.GetDescriptionTextFromLastTextNode();
 
                 var type = typeof(string);
                 var allListedTypes = paramElement.GetListedTypes();

--- a/src/Microsoft.OpenApi.CSharpAnnotations.DocumentGeneration/OperationFilters/ParamToRequestBodyFilter.cs
+++ b/src/Microsoft.OpenApi.CSharpAnnotations.DocumentGeneration/OperationFilters/ParamToRequestBodyFilter.cs
@@ -47,15 +47,7 @@ namespace Microsoft.OpenApi.CSharpAnnotations.DocumentGeneration.OperationFilter
                 var name = bodyElement.Attribute(KnownXmlStrings.Name)?.Value.Trim();
                 var mediaType = bodyElement.Attribute(KnownXmlStrings.Type)?.Value ?? "application/json";
 
-                var childNodes = bodyElement.DescendantNodes().ToList();
-                var description = string.Empty;
-
-                var lastNode = childNodes.LastOrDefault();
-
-                if (lastNode != null && lastNode.NodeType == XmlNodeType.Text)
-                {
-                    description = lastNode.ToString().Trim().RemoveBlankLines();
-                }
+                var description = bodyElement.GetDescriptionTextFromLastTextNode();
 
                 var allListedTypes = bodyElement.GetListedTypes();
 

--- a/src/Microsoft.OpenApi.CSharpAnnotations.DocumentGeneration/OperationFilters/ResponseToResponseFilter.cs
+++ b/src/Microsoft.OpenApi.CSharpAnnotations.DocumentGeneration/OperationFilters/ResponseToResponseFilter.cs
@@ -54,15 +54,7 @@ namespace Microsoft.OpenApi.CSharpAnnotations.DocumentGeneration.OperationFilter
 
                 var mediaType = responseElement.Attribute(KnownXmlStrings.Type)?.Value ?? "application/json";
 
-                var childNodes = responseElement.DescendantNodes().ToList();
-                var description = string.Empty;
-
-                var lastNode = childNodes.LastOrDefault();
-
-                if (lastNode != null && lastNode.NodeType == XmlNodeType.Text)
-                {
-                    description = lastNode.ToString().Trim().RemoveBlankLines();
-                }
+                var description = responseElement.GetDescriptionTextFromLastTextNode();
 
                 var type = typeof(string);
                 var allListedTypes = responseElement.GetListedTypes();

--- a/test/Microsoft.OpenApi.CSharpAnnotations.DocumentGeneration.Tests/ExtensionsTests/XElementExtensionTest.cs
+++ b/test/Microsoft.OpenApi.CSharpAnnotations.DocumentGeneration.Tests/ExtensionsTests/XElementExtensionTest.cs
@@ -35,6 +35,48 @@ namespace Microsoft.OpenApi.CSharpAnnotations.DocumentGeneration.Tests.Extension
             _output = output;
         }
 
+        public static IEnumerable<object[]> GetTestCasesForGetDescriptionTextFromLastTextNodeShouldSucceed()
+        {
+            yield return new object[]
+            {
+                "Elemnt with multiple see tags",
+                XElement.Parse(@"<param name=""sampleHeaderParam2"" in=""header"">"
+        + @"<see cref=""T:System.Collections.Generic.List`1""/>"
+        + @"where T is <see cref=""T:Microsoft.OpenApi.CSharpAnnotations.DocumentGeneration.Tests.Contracts.ISampleObject4`2""/>"
+        + @"where T1 is <see cref=""T:Microsoft.OpenApi.CSharpAnnotations.DocumentGeneration.Tests.Contracts.SampleObject1""/>"
+        + @"where T2 is <see cref=""T:Microsoft.OpenApi.CSharpAnnotations.DocumentGeneration.Tests.Contracts.SampleObject2""/>"
+        + @"Header param 2</param>"),
+                "Header param 2"
+            };
+
+            yield return new object[]
+            {
+                "Element with example tag",
+                XElement.Parse(
+                    "<parent>  Test Request  <example><summary>Test Example</summary>"
+                    +"<url>https://localhost/test.json</url></example></parent>"),
+                "Test Request"
+            };
+
+            yield return new object[]
+            {
+                "Element with response header and example tag",
+                XElement.Parse(@"<parent><example name=""BodyExample"">"
+                + @"<value><see cref=""F:Microsoft.OpenApi.CSharpAnnotations.DocumentGeneration.Tests.Contracts.Examples.SampleObject1Example""/>"
+                +"</value></example>Sample Description<response><header>Test Header</header></response></parent>"),
+                "Sample Description"
+            };
+
+            yield return new object[]
+            {
+                "Element with no child text nodes",
+                XElement.Parse(
+                    "<parent><example><summary>Test Example</summary>"
+                    +"<url>https://localhost/test.json</url></example></parent>"),
+                string.Empty
+            };
+        }
+
         public static IEnumerable<object[]> GetTestCasesForXElementExtensionExampleShouldSucceed()
         {
             yield return new object[]
@@ -236,6 +278,19 @@ namespace Microsoft.OpenApi.CSharpAnnotations.DocumentGeneration.Tests.Extension
                     }
                 }
            };
+        }
+
+        [Theory]
+        [MemberData(nameof(GetTestCasesForGetDescriptionTextFromLastTextNodeShouldSucceed))]
+        public void GetDescriptionTextFromLastTextNodeShouldSucceed(
+            string testCaseName,
+            XElement xElement,
+            string expectedDescriptionText)
+        {
+            _output.WriteLine(testCaseName);
+
+            var description = xElement.GetDescriptionTextFromLastTextNode();
+            description.Should().BeEquivalentTo(expectedDescriptionText);
         }
 
         [Theory]

--- a/test/Microsoft.OpenApi.CSharpAnnotations.DocumentGeneration.Tests/OpenApiDocumentGeneratorTests/Input/Annotation.xml
+++ b/test/Microsoft.OpenApi.CSharpAnnotations.DocumentGeneration.Tests/OpenApiDocumentGeneratorTests/Input/Annotation.xml
@@ -38,7 +38,7 @@
       <group>Sample V1</group>
       <verb>GET</verb>
       <url>http://localhost:9000/V1/samples/{id}?queryBool={queryBool}</url>
-      <param name="sampleHeaderParam1" cref="T:Microsoft.OpenApi.CSharpAnnotations.DocumentGeneration.Tests.Contracts.SampleObject1" in="header"></param>
+      <param name="sampleHeaderParam1" cref="T:Microsoft.OpenApi.CSharpAnnotations.DocumentGeneration.Tests.Contracts.SampleObject1" in="header">Header param 1</param>
       <!-- Header parameter with see tag containing custom type reference -->
       <param name="sampleHeaderParam2" in="header">
         <see cref="T:System.Collections.Generic.List`1"/>

--- a/test/Microsoft.OpenApi.CSharpAnnotations.DocumentGeneration.Tests/OpenApiDocumentGeneratorTests/Input/Annotation.xml
+++ b/test/Microsoft.OpenApi.CSharpAnnotations.DocumentGeneration.Tests/OpenApiDocumentGeneratorTests/Input/Annotation.xml
@@ -38,7 +38,7 @@
       <group>Sample V1</group>
       <verb>GET</verb>
       <url>http://localhost:9000/V1/samples/{id}?queryBool={queryBool}</url>
-      <param name="sampleHeaderParam1" cref="T:Microsoft.OpenApi.CSharpAnnotations.DocumentGeneration.Tests.Contracts.SampleObject1" in="header">Header param 1</param>
+      <param name="sampleHeaderParam1" cref="T:Microsoft.OpenApi.CSharpAnnotations.DocumentGeneration.Tests.Contracts.SampleObject1" in="header"></param>
       <!-- Header parameter with see tag containing custom type reference -->
       <param name="sampleHeaderParam2" in="header">
         <see cref="T:System.Collections.Generic.List`1"/>

--- a/test/Microsoft.OpenApi.CSharpAnnotations.DocumentGeneration.Tests/OpenApiDocumentGeneratorTests/Output/AnnotationExample.Json
+++ b/test/Microsoft.OpenApi.CSharpAnnotations.DocumentGeneration.Tests/OpenApiDocumentGeneratorTests/Output/AnnotationExample.Json
@@ -49,7 +49,7 @@
           {
             "name": "id",
             "in": "path",
-            "description": "",
+            "description": "The object id",
             "required": true,
             "schema": {
               "$ref": "#/components/schemas/Microsoft.OpenApi.CSharpAnnotations.DocumentGeneration.Tests.Contracts.SampleObject1"
@@ -78,7 +78,7 @@
           }
         ],
         "requestBody": {
-          "description": "Request Body Example",
+          "description": "Request Body",
           "content": {
             "application/json": {
               "schema": {
@@ -103,7 +103,7 @@
         },
         "responses": {
           "200": {
-            "description": "Response 200 Example 2",
+            "description": "List of sample objects.",
             "content": {
               "application/json": {
                 "schema": {
@@ -316,7 +316,7 @@
           {
             "name": "id",
             "in": "path",
-            "description": "id2",
+            "description": "The object id",
             "required": true,
             "schema": {
               "type": "string",
@@ -334,7 +334,7 @@
           {
             "name": "queryBool",
             "in": "query",
-            "description": "false",
+            "description": "Sample query boolean",
             "required": true,
             "schema": {
               "type": "boolean",
@@ -382,7 +382,7 @@
           }
         ],
         "requestBody": {
-          "description": "",
+          "description": "Request Body",
           "content": {
             "application/json": {
               "schema": {


### PR DESCRIPTION
If description of the parameter is not the last node e.g in below, then "Request Body Example" will be used as description instead of Request Body

<param name="sampleObject1" in="body"><see cref="T:System.String"/>Request Body
        <example><value>Request Body Example</value></example>
</param>