### PR TITLE
Epet fix reflect file locking

### DIFF
--- a/src/Microsoft.OpenApi.CSharpAnnotations.DocumentGeneration/TypeFetcher.cs
+++ b/src/Microsoft.OpenApi.CSharpAnnotations.DocumentGeneration/TypeFetcher.cs
@@ -137,7 +137,9 @@ namespace Microsoft.OpenApi.CSharpAnnotations.DocumentGeneration
             // Load custom type from the given list of assemblies.
             foreach (var file in _contractAssemblyPaths)
             {
-                var assembly = Assembly.LoadFrom(file);
+                byte[] assemblyBytes = File.ReadAllBytes( file );
+
+                var assembly = Assembly.Load( assemblyBytes );
                 var contractType = assembly.GetType(typeName);
 
                 if (contractType == null)


### PR DESCRIPTION
when not run inside an app domain, reflection causes files to be locked. Change is to copy the file into a byte array and load the assembly.