### PR TITLE
Fetch type for advance config

### DIFF
--- a/src/Microsoft.OpenApi.CSharpAnnotations.DocumentGeneration/InternalOpenApiGenerator.cs
+++ b/src/Microsoft.OpenApi.CSharpAnnotations.DocumentGeneration/InternalOpenApiGenerator.cs
@@ -293,12 +293,21 @@ namespace Microsoft.OpenApi.CSharpAnnotations.DocumentGeneration
                     });
                 }
 
+                IList<string> serializedOperationElements = operationElements.Select(i => i.ToString()).ToList();
+
+                // Operation config elements can contain the types that needs to be fetched too,
+                // so add it to the list of operation elements which will be used to fetch type information.
+                if (operationConfigElement!=null)
+                {
+                    serializedOperationElements.Add(operationConfigElement.ToString());
+                }
+
 #if !NETFRAMEWORK
                 var assemblyLoader = new AssemblyLoader.AssemblyLoader();
                 assemblyLoader.RegisterAssemblyPaths(contractAssemblyPaths);
                 var internalGenerationContextAsString = new AssemblyLoader.AssemblyLoader().BuildInternalGenerationContext(
                     contractAssemblyPaths,
-                    operationElements.Select(i => i.ToString()).ToList(),
+                    serializedOperationElements,
                     propertyElements.Select(i => i.ToString()).ToList(),
                     documentVariantElementNames.FirstOrDefault(),
                     internalSchemaGenerationSettings);
@@ -313,7 +322,7 @@ namespace Microsoft.OpenApi.CSharpAnnotations.DocumentGeneration
                     isolatedDomain.Object.RegisterAssemblyPaths(contractAssemblyPaths);
                     var internalGenerationContextAsString = isolatedDomain.Object.BuildInternalGenerationContext(
                         contractAssemblyPaths,
-                        operationElements.Select(i => i.ToString()).ToList(),
+                        serializedOperationElements,
                         propertyElements.Select(i => i.ToString()).ToList(),
                         documentVariantElementNames.FirstOrDefault(),
                         internalSchemaGenerationSettings);

--- a/src/Microsoft.OpenApi.CSharpAnnotations.DocumentGeneration/Microsoft.OpenApi.CSharpAnnotations.DocumentGeneration.csproj
+++ b/src/Microsoft.OpenApi.CSharpAnnotations.DocumentGeneration/Microsoft.OpenApi.CSharpAnnotations.DocumentGeneration.csproj
@@ -10,7 +10,7 @@
         <Company>Microsoft</Company>
         <Title>Microsoft.OpenApi.CSharpAnnotations.DocumentGeneration</Title>
         <PackageId>Microsoft.OpenApi.CSharpAnnotations.DocumentGeneration</PackageId>
-        <Version>2.0.0-beta01</Version>
+        <Version>2.0.0-beta02</Version>
         <Description>Library that translates Visual Studio C# Annotations into .NET objects representing OpenAPI specification.</Description>
         <Copyright>© Microsoft Corporation. All rights reserved.</Copyright>
         <PackageTags>Microsoft.OpenApi.CSharpAnnotations.DocumentGeneration</PackageTags>

--- a/test/Microsoft.OpenApi.CSharpAnnotations.DocumentGeneration.Tests/Microsoft.OpenApi.CSharpAnnotations.DocumentGeneration.Tests.csproj
+++ b/test/Microsoft.OpenApi.CSharpAnnotations.DocumentGeneration.Tests/Microsoft.OpenApi.CSharpAnnotations.DocumentGeneration.Tests.csproj
@@ -44,6 +44,9 @@
       <None Update="DocumentVariantTests\Input\AnnotationWithDuplicatePaths.xml">
         <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
       </None>
+      <None Update="OperationConfigTests\Input\AnnotationWithNoSimpleTypeReferenceInOperation.xml">
+        <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+      </None>
       <None Update="DocumentVariantTests\Input\AnnotationWithVariantAttributes.xml">
         <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
       </None>
@@ -51,6 +54,9 @@
         <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
       </None>
       <None Update="DocumentVariantTests\Input\AnnotationWithVariantAttributesConflictWithSelf.xml">
+        <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+      </None>
+      <None Update="OperationConfigTests\Input\ConfigWithCommonAnnotations.xml">
         <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
       </None>
       <None Update="DocumentVariantTests\Input\ConfigMultipleDocumentVariantTagsWithCommonAnnotations.xml">
@@ -69,6 +75,9 @@
         <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
       </None>
       <None Update="DocumentVariantTests\Input\Microsoft.OpenApi.CSharpAnnotations.DocumentGeneration.Tests.SampleApis.dll">
+        <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+      </None>
+      <None Update="OperationConfigTests\Output\AnnotationWithNoSimpleTypeReferenceInOperation.json">
         <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
       </None>
       <None Update="DocumentVariantTests\Output\AnnotationDefaultVariant.json">

--- a/test/Microsoft.OpenApi.CSharpAnnotations.DocumentGeneration.Tests/OperationConfigTests/Input/AnnotationWithNoSimpleTypeReferenceInOperation.xml
+++ b/test/Microsoft.OpenApi.CSharpAnnotations.DocumentGeneration.Tests/OperationConfigTests/Input/AnnotationWithNoSimpleTypeReferenceInOperation.xml
@@ -1,0 +1,57 @@
+﻿<?xml version="1.0"?>
+<doc>
+	<assembly>
+		<name>Microsoft.OpenApi.CSharpAnnotations.DocumentGeneration.Tests.SampleApis</name>
+	</assembly>
+	<members>
+		<member name="T:Microsoft.OpenApi.CSharpAnnotations.DocumentGeneration.Tests.SampleApis.RouteConfig">
+			<summary>
+				Responsible for route configuration
+			</summary>
+		</member>
+		<member name="M:Microsoft.OpenApi.CSharpAnnotations.DocumentGeneration.Tests.SampleApis.RouteConfig.RegisterRoutes(System.Web.Routing.RouteCollection)">
+			<summary>
+				Registers routes
+			</summary>
+			<param name="routes">Route collection</param>
+		</member>
+		<member name="T:Microsoft.OpenApi.CSharpAnnotations.DocumentGeneration.Tests.SampleApis.WebApiConfig">
+			<summary>
+				Web config.
+			</summary>
+		</member>
+		<member name="M:Microsoft.OpenApi.CSharpAnnotations.DocumentGeneration.Tests.SampleApis.WebApiConfig.Register(System.Web.Http.HttpConfiguration)">
+			<summary>
+				Register the configuration, services, and routes.
+			</summary>
+			<param name="config">HTTP Configuration</param>
+		</member>
+		<member name="T:Microsoft.OpenApi.CSharpAnnotations.DocumentGeneration.Tests.SampleApis.Controllers.SampleControllerV1">
+			<summary>
+				Define V1 operations.
+			</summary>
+		</member>
+		<member name="M:Microsoft.OpenApi.CSharpAnnotations.DocumentGeneration.Tests.SampleApis.Controllers.SampleControllerV1.SampleGet1(System.String,System.Boolean)">
+			<summary>
+				Sample Get 1
+			</summary>
+			<group>Sample V1</group>
+			<verb>GET</verb>
+			<url>http://localhost:9000/V1/samples/{id}?queryBool={queryBool}</url>
+			<response code="200">
+				<see cref="T:Microsoft.OpenApi.CSharpAnnotations.DocumentGeneration.Tests.Contracts.SampleObject1"/>Sample object retrieved
+			</response>
+			<returns>The sample object 1</returns>
+		</member>
+		<member name="T:Microsoft.OpenApi.CSharpAnnotations.DocumentGeneration.Tests.SampleApis.WebApiApplication">
+			<summary>
+				Web API Application.
+			</summary>
+		</member>
+		<member name="M:Microsoft.OpenApi.CSharpAnnotations.DocumentGeneration.Tests.SampleApis.WebApiApplication.Application_Start">
+			<summary>
+				Start application.
+			</summary>
+		</member>
+	</members>
+</doc>

--- a/test/Microsoft.OpenApi.CSharpAnnotations.DocumentGeneration.Tests/OperationConfigTests/Input/ConfigWithCommonAnnotations.xml
+++ b/test/Microsoft.OpenApi.CSharpAnnotations.DocumentGeneration.Tests/OperationConfigTests/Input/ConfigWithCommonAnnotations.xml
@@ -1,0 +1,8 @@
+﻿<?xml version="1.0"?>
+<configuration>
+  <operation>
+    <annotation>
+      <param name="SampleAddedHeaderParam" required="false" cref="T:System.String" in="header">Added Header Param.</param>
+    </annotation>
+  </operation>
+</configuration>

--- a/test/Microsoft.OpenApi.CSharpAnnotations.DocumentGeneration.Tests/OperationConfigTests/OperationConfigTest.cs
+++ b/test/Microsoft.OpenApi.CSharpAnnotations.DocumentGeneration.Tests/OperationConfigTests/OperationConfigTest.cs
@@ -110,6 +110,34 @@ namespace Microsoft.OpenApi.CSharpAnnotations.DocumentGeneration.Tests.Operation
                     "AnnotationNoOperationConfig.json")
             };
 
+            // Annotation with no simple type but advance config contain simple type as cref.
+            yield return new object[]
+            {
+                "Annotation with no simple type but advance config contain simple type as cref",
+                new List<string>
+                {
+                    Path.Combine(InputDirectory, "AnnotationWithNoSimpleTypeReferenceInOperation.xml"),
+                    Path.Combine(InputDirectory,
+                        "Microsoft.OpenApi.CSharpAnnotations.DocumentGeneration.Tests.Contracts.xml")
+                },
+                new List<string>
+                {
+                    Path.Combine(
+                        InputDirectory,
+                        "Microsoft.OpenApi.CSharpAnnotations.DocumentGeneration.Tests.SampleApis.dll"),
+                    Path.Combine(
+                        InputDirectory,
+                        "Microsoft.OpenApi.CSharpAnnotations.DocumentGeneration.Tests.Contracts.dll")
+                },
+                Path.Combine(
+                    InputDirectory,
+                    "ConfigWithCommonAnnotations.xml"),
+                1,
+                Path.Combine(
+                    OutputDirectory,
+                    "AnnotationWithNoSimpleTypeReferenceInOperation.json")
+            };
+
             // Blank operation section in config files
             yield return new object[]
             {

--- a/test/Microsoft.OpenApi.CSharpAnnotations.DocumentGeneration.Tests/OperationConfigTests/Output/AnnotationWithNoSimpleTypeReferenceInOperation.json
+++ b/test/Microsoft.OpenApi.CSharpAnnotations.DocumentGeneration.Tests/OperationConfigTests/Output/AnnotationWithNoSimpleTypeReferenceInOperation.json
@@ -1,0 +1,92 @@
+{
+    "openapi": "3.0.1",
+    "info": {
+        "title": "Microsoft.OpenApi.CSharpAnnotations.DocumentGeneration.Tests.SampleApis",
+        "version": "1.0.0"
+    },
+    "servers": [
+        {
+            "url": "http://localhost:9000"
+        }
+    ],
+    "paths": {
+        "/V1/samples/{id}": {
+            "get": {
+                "tags": [
+                    "Sample V1"
+                ],
+                "summary": "Sample Get 1",
+                "operationId": "getV1SamplesById",
+                "parameters": [
+                    {
+                        "name": "SampleAddedHeaderParam",
+                        "in": "header",
+                        "description": "Added Header Param.",
+                        "schema": {
+                            "type": "string"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Sample object retrieved",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/Microsoft.OpenApi.CSharpAnnotations.DocumentGeneration.Tests.Contracts.SampleObject1"
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    },
+    "components": {
+        "schemas": {
+            "Microsoft.OpenApi.CSharpAnnotations.DocumentGeneration.Tests.Contracts.SampleObject1": {
+                "required": [
+                    "samplePropertyString3",
+                    "samplePropertyString4",
+                    "samplePropertyEnum"
+                ],
+                "type": "object",
+                "properties": {
+                    "samplePropertyBool": {
+                        "type": "boolean",
+                        "description": "Gets or sets the sample property bool"
+                    },
+                    "samplePropertyStringInt": {
+                        "type": "integer",
+                        "description": "Gets or sets the sample property int",
+                        "format": "int32"
+                    },
+                    "samplePropertyString1": {
+                        "type": "string",
+                        "description": "Gets or sets the sample property string 1"
+                    },
+                    "samplePropertyString2": {
+                        "type": "string",
+                        "description": "Gets or sets the sample property string 2"
+                    },
+                    "samplePropertyString3": {
+                        "type": "string",
+                        "description": "Gets or sets the sample property string 3"
+                    },
+                    "samplePropertyString4": {
+                        "type": "string",
+                        "description": "Gets or sets the sample property string 4"
+                    },
+                    "samplePropertyEnum": {
+                        "enum": [
+                            "SampleEnumValue1",
+                            "SampleEnumValue2"
+                        ],
+                        "type": "string",
+                        "description": "Gets or sets the sample property enum"
+                    }
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
Advance config can contain types that might not be referenced in operation elements in annotation xml so this code change is to fetch type information for advance config elements too.