### PR TITLE
Add TimeSpan handling to TypeExtensions

### DIFF
--- a/src/Microsoft.OpenApi.CSharpAnnotations.DocumentGeneration/Extensions/TypeExtensions.cs
+++ b/src/Microsoft.OpenApi.CSharpAnnotations.DocumentGeneration/Extensions/TypeExtensions.cs
@@ -31,6 +31,7 @@ namespace Microsoft.OpenApi.CSharpAnnotations.DocumentGeneration.Extensions
                 [typeof(decimal)] = () => new OpenApiSchema {Type = "number", Format = "double"},
                 [typeof(DateTime)] = () => new OpenApiSchema {Type = "string", Format = "date-time"},
                 [typeof(DateTimeOffset)] = () => new OpenApiSchema {Type = "string", Format = "date-time"},
+                [typeof(TimeSpan)] = () => new OpenApiSchema {Type = "string"},
                 [typeof(Guid)] = () => new OpenApiSchema {Type = "string", Format = "uuid"},
                 [typeof(char)] = () => new OpenApiSchema {Type = "string"},
 
@@ -45,6 +46,7 @@ namespace Microsoft.OpenApi.CSharpAnnotations.DocumentGeneration.Extensions
                 [typeof(double?)] = () => new OpenApiSchema {Type = "number", Format = "double", Nullable = true},
                 [typeof(decimal?)] = () => new OpenApiSchema {Type = "number", Format = "double", Nullable = true},
                 [typeof(DateTime?)] = () => new OpenApiSchema {Type = "string", Format = "date-time", Nullable = true},
+                [typeof(TimeSpan?)] = () => new OpenApiSchema {Type = "string"},
                 [typeof(DateTimeOffset?)] = () =>
                     new OpenApiSchema {Type = "string", Format = "date-time", Nullable = true},
                 [typeof(Guid?)] = () => new OpenApiSchema {Type = "string", Format = "uuid", Nullable = true},

--- a/src/Microsoft.OpenApi.CSharpAnnotations.DocumentGeneration/Extensions/TypeExtensions.cs
+++ b/src/Microsoft.OpenApi.CSharpAnnotations.DocumentGeneration/Extensions/TypeExtensions.cs
@@ -46,7 +46,7 @@ namespace Microsoft.OpenApi.CSharpAnnotations.DocumentGeneration.Extensions
                 [typeof(double?)] = () => new OpenApiSchema {Type = "number", Format = "double", Nullable = true},
                 [typeof(decimal?)] = () => new OpenApiSchema {Type = "number", Format = "double", Nullable = true},
                 [typeof(DateTime?)] = () => new OpenApiSchema {Type = "string", Format = "date-time", Nullable = true},
-                [typeof(TimeSpan?)] = () => new OpenApiSchema {Type = "string"},
+                [typeof(TimeSpan?)] = () => new OpenApiSchema {Type = "string", Nullable = true},
                 [typeof(DateTimeOffset?)] = () =>
                     new OpenApiSchema {Type = "string", Format = "date-time", Nullable = true},
                 [typeof(Guid?)] = () => new OpenApiSchema {Type = "string", Format = "uuid", Nullable = true},


### PR DESCRIPTION
My team is using the OpenAPI ADO build tasks to generate the OpenAPI JSON spec from our REST API. Really appreciate the nice integration with our ADO build pipelines!

We've run into a small issue with TimeSpan handling, since these properties are returned in the serialized JSON response as strings. Please let me know if there is any additional process around submitting changes to this repository, or if there is a different recommended approach here. Thanks!

Previously reported in #217 