### PR TITLE
Add predefined operationId support.

### DIFF
--- a/src/Microsoft.OpenApi.CSharpAnnotations.DocumentGeneration/Exceptions/InvalidOperationIdException.cs
+++ b/src/Microsoft.OpenApi.CSharpAnnotations.DocumentGeneration/Exceptions/InvalidOperationIdException.cs
@@ -1,0 +1,24 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license. 
+
+using System;
+
+namespace Microsoft.OpenApi.CSharpAnnotations.DocumentGeneration.Exceptions
+{
+    /// <summary>
+    /// The exception that is recorded when it is expected to have operationId XML tag 
+    /// but it is missing or there are more than one tags.
+    /// </summary>
+    [Serializable]
+    internal class InvalidOperationIdException : DocumentationException
+    {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="InvalidOperationIdException"/>.
+        /// </summary>
+        /// <param name="message">Error message.</param>
+        public InvalidOperationIdException(string message = "")
+            : base(message)
+        {
+        }
+    }
+}

--- a/src/Microsoft.OpenApi.CSharpAnnotations.DocumentGeneration/FilterSet.cs
+++ b/src/Microsoft.OpenApi.CSharpAnnotations.DocumentGeneration/FilterSet.cs
@@ -113,7 +113,7 @@ namespace Microsoft.OpenApi.CSharpAnnotations.DocumentGeneration
                         _defaultFilterSet.Add(new PopulateInAttributeFilter());
                         _defaultFilterSet.Add(new ConvertAlternativeParamTagsFilter());
                         _defaultFilterSet.Add(new ValidateInAttributeFilter());
-                        _defaultFilterSet.Add(new BranchOptionalPathParametersFilter());
+                        _defaultFilterSet.Add(new CreateOperationMetaFilter());
 
                         //Post processing document filters
                         _defaultFilterSet.Add(new RemoveFailedGenerationOperationFilter());

--- a/src/Microsoft.OpenApi.CSharpAnnotations.DocumentGeneration/InternalOpenApiGenerator.cs
+++ b/src/Microsoft.OpenApi.CSharpAnnotations.DocumentGeneration/InternalOpenApiGenerator.cs
@@ -501,7 +501,7 @@ namespace Microsoft.OpenApi.CSharpAnnotations.DocumentGeneration
 
                 try
                 {
-                    operationMethod = OperationHandler.GetOperationMethod(url, operationElement);
+                    operationMethod = OperationHandler.GetOperationMethod(operationElement);
                 }
                 catch (InvalidVerbException e)
                 {

--- a/src/Microsoft.OpenApi.CSharpAnnotations.DocumentGeneration/Models/KnownStrings/KnownXmlStrings.cs
+++ b/src/Microsoft.OpenApi.CSharpAnnotations.DocumentGeneration/Models/KnownStrings/KnownXmlStrings.cs
@@ -64,6 +64,7 @@ namespace Microsoft.OpenApi.CSharpAnnotations.DocumentGeneration.Models.KnownStr
         public const string AuthorizationCode = "authorizationCode";
         public const string ClientCredentials = "clientCredentials";
         public const string Scope = "scope";
+        public const string OperationId = "operationId";
         public static string[] AllowedAppKeyInValues => new[] {Header, Query, Cookie};
 
         public static string[] AllowedFlowTypeValues => new[]

--- a/src/Microsoft.OpenApi.CSharpAnnotations.DocumentGeneration/PreprocessingOperationFilters/CreateOperationMetaFilter.cs
+++ b/src/Microsoft.OpenApi.CSharpAnnotations.DocumentGeneration/PreprocessingOperationFilters/CreateOperationMetaFilter.cs
@@ -1,0 +1,82 @@
+﻿// ------------------------------------------------------------
+//  Copyright (c) Microsoft Corporation.  All rights reserved.
+//  Licensed under the MIT License (MIT). See License.txt in the repo root for license information.
+// ------------------------------------------------------------
+
+using System;
+using System.Collections.Generic;
+using System.Xml.Linq;
+using Microsoft.OpenApi.CSharpAnnotations.DocumentGeneration.Models;
+using Microsoft.OpenApi.Models;
+
+namespace Microsoft.OpenApi.CSharpAnnotations.DocumentGeneration.PreprocessingOperationFilters
+{
+    /// <summary>
+    /// Filter to initialize OpenApi operation based on the annotation XML element.
+    /// 
+    /// It does not do the creation itself but forwards the call to the real generator filters.
+    /// The first filter which is applicable is executed in order to generate the operation.
+    /// </summary>
+    public class CreateOperationMetaFilter : IPreProcessingOperationFilter
+    {
+        private List<ICreateOperationPreProcessingOperationFilter> createOperationFilters;
+
+        /// <summary>
+        /// Initializes a new production instance of the <see cref="CreateOperationMetaFilter"/>.
+        /// </summary>
+        /// <remarks>
+        /// Using this constructor, the following filter list is used:
+        /// If the XML element contains 'operationId' tag, it is used as unique identifier
+        /// of the operation. Otherwise, the id is generated using the path of the operation.
+        /// In the latter case, multiple operation could be generated, if the path has optional
+        /// parameters.
+        /// </remarks>
+        public CreateOperationMetaFilter() :
+            this(new List<ICreateOperationPreProcessingOperationFilter> {
+                new UsePredefinedOperationIdFilter(), new BranchOptionalPathParametersFilter()})
+        {
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="CreateOperationMetaFilter"/>.
+        /// </summary>
+        /// <param name="createOperationFilters">List of generator filters.</param>
+        internal CreateOperationMetaFilter(
+            List<ICreateOperationPreProcessingOperationFilter> createOperationFilters)
+        {
+            this.createOperationFilters = createOperationFilters;
+        }
+
+        /// <summary>
+        /// Initializes the OpenApi operation based on the annotation XML element.
+        /// 
+        /// </summary>
+        /// <param name="paths">The paths to be updated.</param>
+        /// <param name="element">The xml element representing an operation in the annotation xml.</param>
+        /// <param name="settings">The operation filter settings.</param>
+        /// <returns>The list of generation errors, if any produced when processing the filter.</returns>
+        public IList<GenerationError> Apply(
+            OpenApiPaths paths,
+            XElement element,
+            PreProcessingOperationFilterSettings settings)
+        {
+            foreach (var filter in this.createOperationFilters)
+            {
+                if (filter.IsApplicable(element))
+                {
+                    return filter.Apply(paths, element, settings);
+                }
+            }
+
+            // If none of the filters could be applied --> error
+            return new List<GenerationError>
+            {
+                new GenerationError
+                {
+                    Message = "Failed to apply any operation creation filter.",
+                    ExceptionType = nameof(InvalidOperationException)
+                }
+            };
+        }
+    }
+}

--- a/src/Microsoft.OpenApi.CSharpAnnotations.DocumentGeneration/PreprocessingOperationFilters/ICreateOperationPreProcessingOperationFilter.cs
+++ b/src/Microsoft.OpenApi.CSharpAnnotations.DocumentGeneration/PreprocessingOperationFilters/ICreateOperationPreProcessingOperationFilter.cs
@@ -1,0 +1,28 @@
+﻿// ------------------------------------------------------------
+//  Copyright (c) Microsoft Corporation.  All rights reserved.
+//  Licensed under the MIT License (MIT). See License.txt in the repo root for license information.
+// ------------------------------------------------------------
+
+using System.Collections.Generic;
+using System.Xml.Linq;
+using Microsoft.OpenApi.CSharpAnnotations.DocumentGeneration.Models;
+using Microsoft.OpenApi.CSharpAnnotations.DocumentGeneration.OperationFilters;
+using Microsoft.OpenApi.Models;
+
+namespace Microsoft.OpenApi.CSharpAnnotations.DocumentGeneration.PreprocessingOperationFilters
+{
+    /// <summary>
+    /// The class representing the contract of a filter to preprocess the <see cref="OpenApiOperation"/>
+    /// objects in <see cref="OpenApiPaths"/> before each <see cref="OpenApiOperation"/> is processed by the
+    /// <see cref="IOperationFilter"/>.
+    /// </summary>
+    public interface ICreateOperationPreProcessingOperationFilter : IPreProcessingOperationFilter
+    {
+        /// <summary>
+        /// Verifies that the annotation XML element contains all data which are required to apply this filter.
+        /// </summary>
+        /// <param name="element">The xml element representing an operation in the annotation xml.</param>
+        /// <returns>True if the filter can be applied, otherwise false.</returns>
+        bool IsApplicable(XElement element);
+    }
+}

--- a/src/Microsoft.OpenApi.CSharpAnnotations.DocumentGeneration/PreprocessingOperationFilters/UsePredefinedOperationIdFilter.cs
+++ b/src/Microsoft.OpenApi.CSharpAnnotations.DocumentGeneration/PreprocessingOperationFilters/UsePredefinedOperationIdFilter.cs
@@ -1,0 +1,112 @@
+﻿// ------------------------------------------------------------
+//  Copyright (c) Microsoft Corporation.  All rights reserved.
+//  Licensed under the MIT License (MIT). See License.txt in the repo root for license information.
+// ------------------------------------------------------------
+
+using System;
+using System.Collections.Generic;
+using System.Xml.Linq;
+using Microsoft.OpenApi.CSharpAnnotations.DocumentGeneration.Models;
+using Microsoft.OpenApi.Models;
+
+namespace Microsoft.OpenApi.CSharpAnnotations.DocumentGeneration.PreprocessingOperationFilters
+{
+    /// <summary>
+    /// Filter to creates operation using the 'operationId' tag of the operation.
+    /// It does not consider optional parameters, it create one operation for the full path.
+    /// </summary>
+    public class UsePredefinedOperationIdFilter : ICreateOperationPreProcessingOperationFilter
+    {
+        private readonly Func<XElement, string> GetUrlFunc;
+        private readonly Func<XElement, OperationType> GetOperationMethodFunc;
+        private readonly Func<XElement, string> GetOperationIdFunc;
+        private readonly Predicate<XElement> HasOperationIdFunc;
+
+        /// <summary>
+        /// Initializes a new production instance of the <see cref="UsePredefinedOperationIdFilter"/>.
+        /// </summary>
+        public UsePredefinedOperationIdFilter()
+            : this(
+                  OperationHandler.GetUrl,
+                  OperationHandler.GetOperationMethod,
+                  OperationHandler.GetOperationId,
+                  OperationHandler.HasOperationId)
+        {
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="UsePredefinedOperationIdFilter"/>.
+        /// </summary>
+        /// <param name="GetUrlFunc">Get url function.</param>
+        /// <param name="GetOperationMethodFunc">Get operation method function.</param>
+        /// <param name="GetOperationIdFunc">Get operation id function.</param>
+        /// <param name="HasOperationIdFunc">Has operation id function.</param>
+        public UsePredefinedOperationIdFilter(
+            Func<XElement, string> GetUrlFunc,
+            Func<XElement, OperationType> GetOperationMethodFunc,
+            Func<XElement, string> GetOperationIdFunc,
+            Predicate<XElement> HasOperationIdFunc)
+        {
+            this.GetUrlFunc = GetUrlFunc;
+            this.GetOperationMethodFunc = GetOperationMethodFunc;
+            this.GetOperationIdFunc = GetOperationIdFunc;
+            this.HasOperationIdFunc = HasOperationIdFunc;
+        }
+
+        /// <summary>
+        /// Verifies whether the annotation XML element contains operationId XML tag.
+        /// </summary>
+        /// <param name="element">The xml element representing an operation in the annotation xml.</param>
+        /// <returns></returns>
+        public bool IsApplicable(XElement element)
+        {
+            return this.HasOperationIdFunc(element);
+        }
+
+        /// <summary>
+        /// Creates the operation in the Paths object using the operationId tag of the operation.
+        /// It does not consider optional parameters, it create one operation for the full path.
+        /// the URL value and creates multiple operations based on optional parameters.
+        /// </summary>
+        /// <param name="paths">The paths to be updated.</param>
+        /// <param name="element">The xml element representing an operation in the annotation xml.</param>
+        /// <param name="settings">The operation filter settings.</param>
+        /// <returns>The list of generation errors, if any produced when processing the filter.</returns>
+        public IList<GenerationError> Apply(
+            OpenApiPaths paths,
+            XElement element,
+            PreProcessingOperationFilterSettings settings)
+        {
+            var generationErrors = new List<GenerationError>();
+
+            try
+            {
+                var absolutePath = this.GetUrlFunc(element);
+                var operationMethod = this.GetOperationMethodFunc(element);
+                string operationId = this.GetOperationIdFunc(element);
+
+                if (!paths.ContainsKey(absolutePath))
+                {
+                    paths[absolutePath] = new OpenApiPathItem();
+                }
+
+                paths[absolutePath].Operations[operationMethod] =
+                    new OpenApiOperation
+                    {
+                        OperationId = operationId
+                    };
+            }
+            catch(Exception ex)
+            {
+                generationErrors.Add(
+                   new GenerationError
+                   {
+                       Message = ex.Message,
+                       ExceptionType = ex.GetType().Name
+                   });
+            }
+
+            return generationErrors;
+        }
+    }
+}

--- a/src/Microsoft.OpenApi.CSharpAnnotations.DocumentGeneration/SpecificationGenerationMessages.cs
+++ b/src/Microsoft.OpenApi.CSharpAnnotations.DocumentGeneration/SpecificationGenerationMessages.cs
@@ -123,5 +123,9 @@ namespace Microsoft.OpenApi.CSharpAnnotations.DocumentGeneration
 
         public const string NotSupportedTypeAttributeValue =
             "Documented type: \"{0}\" is not supported for \"type\" attribute value in tag: \"{1}\". Supported values are: {2}.";
+
+        public const string NoOperationId = "No operationId element is present in the operation.";
+
+        public const string MultipleOperationId = "More than one operationId element is not accepted in the operation.";
     }
 }

--- a/test/Microsoft.OpenApi.CSharpAnnotations.DocumentGeneration.Tests/FilterTests/CreateOperationMetaFilterTest.cs
+++ b/test/Microsoft.OpenApi.CSharpAnnotations.DocumentGeneration.Tests/FilterTests/CreateOperationMetaFilterTest.cs
@@ -1,0 +1,239 @@
+﻿// ------------------------------------------------------------
+//  Copyright (c) Microsoft Corporation.  All rights reserved.
+//  Licensed under the MIT License (MIT). See License.txt in the repo root for license information.
+// ------------------------------------------------------------
+
+using System.Collections.Generic;
+using System.Linq;
+using System.Xml.Linq;
+using FluentAssertions;
+using Microsoft.OpenApi.CSharpAnnotations.DocumentGeneration.Models;
+using Microsoft.OpenApi.CSharpAnnotations.DocumentGeneration.PreprocessingOperationFilters;
+using Microsoft.OpenApi.Models;
+using Moq;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace Microsoft.OpenApi.CSharpAnnotations.DocumentGeneration.Tests.FilterTests
+{
+    [Collection("DefaultSettings")]
+    public class CreateOperationMetaFilterTest
+    {
+        private readonly ITestOutputHelper _output;
+
+        public CreateOperationMetaFilterTest(ITestOutputHelper output)
+        {
+            _output = output;
+        }
+
+        [Theory]
+        [MemberData(nameof(GetTestCasesForApplyShouldCallOnlyTheFirstFilterWhichIsApplicable))]
+        public void ApplyShouldCallOnlyTheFirstFilterWhichIsApplicable(
+            string testName,
+            List<Mock<ICreateOperationPreProcessingOperationFilter>> mockFilters,
+            int firstApplicableFilterIndex)
+        {
+            _output.WriteLine(testName);
+
+            // Prepare
+            var openApiPaths = new OpenApiPaths();
+            XElement element = new XElement("elem");
+            var settings = new PreProcessingOperationFilterSettings();
+
+            List<ICreateOperationPreProcessingOperationFilter> filters =
+                mockFilters.Select(mockFilter => mockFilter.Object).ToList();
+
+            var filter = new CreateOperationMetaFilter(filters);
+
+            // Action
+            filter.Apply(openApiPaths, element, settings);
+
+            // Assert
+            for(int i = 0; i < firstApplicableFilterIndex - 1; ++i)
+            {
+                mockFilters[i].Verify(mock => mock.Apply(
+                    It.IsAny<OpenApiPaths>(), It.IsAny<XElement>(), It.IsAny<PreProcessingOperationFilterSettings>()),
+                    Times.Never());
+            }
+
+            for (int i = firstApplicableFilterIndex + 1; i < mockFilters.Count; ++i)
+            {
+                mockFilters[i].Verify(mock => mock.Apply(
+                    It.IsAny<OpenApiPaths>(), It.IsAny<XElement>(), It.IsAny<PreProcessingOperationFilterSettings>()),
+                    Times.Never());
+            }
+
+            mockFilters[firstApplicableFilterIndex].Verify(mock => mock.Apply(
+                openApiPaths, element, settings), Times.Once());
+        }
+
+        [Fact]
+        public void ApplyShouldReturnErrorIfNoneOfTheFiltersCouldBeApplied()
+        {
+            // Prepare
+            var openApiPaths = new OpenApiPaths();
+            XElement element = new XElement("elem");
+            var settings = new PreProcessingOperationFilterSettings();
+
+            var mockFilters = new List<Mock<ICreateOperationPreProcessingOperationFilter>>{
+                    CreateMockFilter(false),
+                    CreateMockFilter(false),
+                    CreateMockFilter(false)};
+
+            List<ICreateOperationPreProcessingOperationFilter> filters =
+                mockFilters.Select(mockFilter => mockFilter.Object).ToList();
+
+            var filter = new CreateOperationMetaFilter(filters);
+
+            // Action
+            var errorList = filter.Apply(openApiPaths, element, settings);
+
+            // Assert
+            errorList.Should().OnlyContain(error => error.ExceptionType == "InvalidOperationException");
+        }
+
+        [Fact]
+        public void ApplyShouldNotReturnErrorIfTheAppliedFilterDoesNotReturnError()
+        {
+            // Prepare
+            var openApiPaths = new OpenApiPaths();
+            XElement element = new XElement("elem");
+            var settings = new PreProcessingOperationFilterSettings();
+
+            var successfullFilter = CreateMockFilter(true);
+
+            var mockFilters = new List<Mock<ICreateOperationPreProcessingOperationFilter>>{
+                    successfullFilter};
+
+            List<ICreateOperationPreProcessingOperationFilter> filters =
+                mockFilters.Select(mockFilter => mockFilter.Object).ToList();
+
+            var filter = new CreateOperationMetaFilter(filters);
+
+            // Action
+            var errorList = filter.Apply(openApiPaths, element, settings);
+
+            // Assert
+            errorList.Should().BeEmpty();
+        }
+
+        [Fact]
+        public void ApplyShouldReturnTheErrorListOFTheAppliedFilter()
+        {
+            // Prepare
+            var openApiPaths = new OpenApiPaths();
+            XElement element = new XElement("elem");
+            var settings = new PreProcessingOperationFilterSettings();
+
+            var mockFilterWithError = new Mock<ICreateOperationPreProcessingOperationFilter>();
+
+            var expectedErrorList = new List<GenerationError>
+            {
+                new GenerationError
+                {
+                    Message = "Message_1",
+                    ExceptionType = "ExceptionType_1"
+                },
+                new GenerationError
+                {
+                    Message = "Message_2",
+                    ExceptionType = "ExceptionType_2"
+                }
+            };
+
+            mockFilterWithError.Setup(
+                mock => mock.Apply(
+                    It.IsAny<OpenApiPaths>(), It.IsAny<XElement>(), It.IsAny<PreProcessingOperationFilterSettings>()))
+                .Returns(expectedErrorList);
+
+            mockFilterWithError.Setup(mock => mock.IsApplicable(It.IsAny<XElement>())).Returns(true);
+
+            var mockFilters = new List<Mock<ICreateOperationPreProcessingOperationFilter>>
+            {
+                mockFilterWithError
+            };
+
+            List<ICreateOperationPreProcessingOperationFilter> filters =
+                mockFilters.Select(mockFilter => mockFilter.Object).ToList();
+
+            // Action
+            var filter = new CreateOperationMetaFilter(filters);
+            var errorList = filter.Apply(openApiPaths, element, settings);
+
+            // Assert
+            errorList.Should().ContainInOrder(expectedErrorList);
+        }
+
+        public static IEnumerable<object[]> GetTestCasesForApplyShouldCallOnlyTheFirstFilterWhichIsApplicable()
+        {
+            yield return new object[]
+            {
+                "Only the first filter is applicable",
+                new List<Mock<ICreateOperationPreProcessingOperationFilter>>{
+                    CreateMockFilter(true),
+                    CreateMockFilter(false),
+                    CreateMockFilter(false)
+                },
+                0
+            };
+
+            yield return new object[]
+{
+                "Only the last filter is applicable",
+                new List<Mock<ICreateOperationPreProcessingOperationFilter>>{
+                    CreateMockFilter(false),
+                    CreateMockFilter(false),
+                    CreateMockFilter(true)
+                },
+                2
+            };
+
+            yield return new object[]
+            {
+                "Only one filter in the middle is applicable",
+                new List<Mock<ICreateOperationPreProcessingOperationFilter>>{
+                    CreateMockFilter(false),
+                    CreateMockFilter(true),
+                    CreateMockFilter(false)
+                },
+                1
+            };
+
+            yield return new object[]
+            {
+                "The first applicable filter masks the other applicable filters",
+                new List<Mock<ICreateOperationPreProcessingOperationFilter>>{
+                    CreateMockFilter(false),
+                    CreateMockFilter(true),
+                    CreateMockFilter(true)
+                },
+                1
+            };
+
+            yield return new object[]
+            {
+                "If all filters are applicable, only the first one is called",
+                new List<Mock<ICreateOperationPreProcessingOperationFilter>>{
+                    CreateMockFilter(true),
+                    CreateMockFilter(true),
+                    CreateMockFilter(true)
+                },
+                0
+            };
+        }
+
+        private static Mock<ICreateOperationPreProcessingOperationFilter> CreateMockFilter(bool applicable)
+        {
+            var mockFilter = new Mock<ICreateOperationPreProcessingOperationFilter>();
+
+            mockFilter.Setup(
+                mock => mock.Apply(
+                    It.IsAny<OpenApiPaths>(), It.IsAny<XElement>(), It.IsAny<PreProcessingOperationFilterSettings>()))
+                .Returns(new List<GenerationError>());
+
+            mockFilter.Setup(mock => mock.IsApplicable(It.IsAny<XElement>())).Returns(applicable);
+
+            return mockFilter;
+        }
+    }
+}

--- a/test/Microsoft.OpenApi.CSharpAnnotations.DocumentGeneration.Tests/FilterTests/UsePredefinedOperationIdFilterTest.cs
+++ b/test/Microsoft.OpenApi.CSharpAnnotations.DocumentGeneration.Tests/FilterTests/UsePredefinedOperationIdFilterTest.cs
@@ -1,0 +1,389 @@
+﻿// ------------------------------------------------------------
+//  Copyright (c) Microsoft Corporation.  All rights reserved.
+//  Licensed under the MIT License (MIT). See License.txt in the repo root for license information.
+// ------------------------------------------------------------
+
+using System;
+using System.Collections.Generic;
+using System.Xml.Linq;
+using FluentAssertions;
+using Microsoft.OpenApi.CSharpAnnotations.DocumentGeneration.Exceptions;
+using Microsoft.OpenApi.CSharpAnnotations.DocumentGeneration.PreprocessingOperationFilters;
+using Microsoft.OpenApi.Models;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace Microsoft.OpenApi.CSharpAnnotations.DocumentGeneration.Tests.FilterTests
+{
+    [Collection("DefaultSettings")]
+    public class UsePredefinedOperationIdFilterTest
+    {
+        private readonly ITestOutputHelper _output;
+
+        public UsePredefinedOperationIdFilterTest(ITestOutputHelper output)
+        {
+            _output = output;
+        }
+
+        [Theory]
+        [MemberData(nameof(GetTestCasesForIsApplicableShouldReferToTheHasOperationIdPredicate))]
+        public void IsApplicableShouldReferToTheHasOperationIdPredicate(
+            string testName,
+            bool shouldBeApplicable)
+        {
+            _output.WriteLine(testName);
+
+            // Prepare
+            XElement calledElement = null;
+            bool mockHasOperationIdFunc(XElement e)
+            {
+                calledElement = e;
+                return shouldBeApplicable;
+            }
+
+            var filter = new UsePredefinedOperationIdFilter(
+                DefaultGetUrlFunc,
+                DefaultGetOperationMethodFunc,
+                DefaultGetOperationIdFunc,
+                mockHasOperationIdFunc);
+
+            var element = XElement.Parse("<xml>Not used in this test due of the mocked function.</xml>");
+
+            // Action
+            var result = filter.IsApplicable(element);
+
+            // Assert
+            result.Should().Be(shouldBeApplicable);
+        }
+
+        [Fact]
+        public void ApplyShouldCreateTheExpectedOpenApiPath()
+        {
+            // Prepare
+            var expectedUrl = "/expected/operation/path";
+            var expectedOperationType = OperationType.Post;
+            var expectedOperationId = "Expected_Operation_Id";
+
+            string MockGetUrlFunc(XElement e)
+            {
+                return (string)expectedUrl.Clone();
+            }
+
+            OperationType MockGetOperationTypeFunc(XElement e)
+            {
+                return expectedOperationType;
+            }
+
+            string MockGetOperationIdFunc(XElement e)
+            {
+                return (string)expectedOperationId.Clone();
+            }
+
+
+            var filter = new UsePredefinedOperationIdFilter(
+                MockGetUrlFunc,
+                MockGetOperationTypeFunc,
+                MockGetOperationIdFunc,
+                DefaultHasOperationIdFunc);
+
+            var element = XElement.Parse("<xml>Not used in this test due of the mocked functions.</xml>");
+
+            // Action
+            var openApiPaths = new OpenApiPaths();
+            var result = filter.Apply(openApiPaths, element, new PreProcessingOperationFilterSettings());
+
+            // Assert
+            result.Should().BeEmpty();
+
+            openApiPaths.Keys.Count.Should().Be(1);
+            openApiPaths.Should().ContainKey(expectedUrl);
+
+            openApiPaths[expectedUrl].Operations.Keys.Count.Should().Be(1);
+            openApiPaths[expectedUrl].Operations.Should().ContainKey(expectedOperationType);
+
+            openApiPaths[expectedUrl].Operations[expectedOperationType]
+                .OperationId.Should().BeEquivalentTo(expectedOperationId);
+        }
+
+        [Fact]
+        public void ApplyShouldReturnTheExpectedErrorIfGetUrlThrowsException()
+        {
+            // Prepare
+            string MockGetUlrFunc(XElement e)
+            {
+                throw new InvalidUrlException();
+            }
+
+            var filter = new UsePredefinedOperationIdFilter(
+                MockGetUlrFunc,
+                DefaultGetOperationMethodFunc,
+                DefaultGetOperationIdFunc,
+                DefaultHasOperationIdFunc);
+
+            var element = XElement.Parse("<xml>Not used in this test due of the mocked functions.</xml>");
+
+            // Action
+            var openApiPaths = new OpenApiPaths();
+            var result = filter.Apply(openApiPaths, element, new PreProcessingOperationFilterSettings());
+
+            // Assert
+            result.Count.Should().Be(1);
+            result[0].ExceptionType.Should().Be("InvalidUrlException");
+            openApiPaths.Keys.Count.Should().Be(0);
+        }
+
+        [Fact]
+        public void ApplyShouldReturnTheExpectedErrorIfGetOperationMethodThrowsException()
+        {
+            // Prepare
+            OperationType MockGetOperationMethodFunc(XElement e)
+            {
+                throw new InvalidVerbException();
+            }
+
+            var filter = new UsePredefinedOperationIdFilter(
+                DefaultGetUrlFunc,
+                MockGetOperationMethodFunc,
+                DefaultGetOperationIdFunc,
+                DefaultHasOperationIdFunc);
+
+            var element = XElement.Parse("<xml>Not used in this test due of the mocked functions.</xml>");
+
+            // Action
+            var openApiPaths = new OpenApiPaths();
+            var result = filter.Apply(openApiPaths, element, new PreProcessingOperationFilterSettings());
+
+            // Assert
+            result.Count.Should().Be(1);
+            result[0].ExceptionType.Should().Be("InvalidVerbException");
+            openApiPaths.Keys.Count.Should().Be(0);
+        }
+
+        [Fact]
+        public void ApplyShouldReturnTheExpectedErrorIfGetOperationIdThrowsException()
+        {
+            // Prepare
+            string MockGetOperationIdFunc(XElement e)
+            {
+                throw new InvalidOperationIdException();
+            }
+
+            var filter = new UsePredefinedOperationIdFilter(
+                DefaultGetUrlFunc,
+                DefaultGetOperationMethodFunc,
+                MockGetOperationIdFunc,
+                DefaultHasOperationIdFunc);
+
+            var element = XElement.Parse("<xml>Not used in this test due of the mocked functions.</xml>");
+
+            // Action
+            var openApiPaths = new OpenApiPaths();
+            var result = filter.Apply(openApiPaths, element, new PreProcessingOperationFilterSettings());
+
+            // Assert
+            result.Count.Should().Be(1);
+            result[0].ExceptionType.Should().Be("InvalidOperationIdException");
+            openApiPaths.Keys.Count.Should().Be(0);
+        }
+
+        public static IEnumerable<object[]> GetTestCasesForIsApplicableShouldReferToTheHasOperationIdPredicate()
+        {
+            yield return new object[]
+            {
+                "Applicable is HasOperationId returns true",
+                true
+            };
+
+            yield return new object[]
+            {
+                "Not applicable is HasOperationId returns false",
+                false
+            };
+        }
+
+        //[Fact]
+        //public void ApplyShouldUseTheOperationIdXmlTagAsOperationId()
+        //{
+        //    // Prepare
+        //    var element = XElement.Parse(@"
+        //            <member>
+        //                <summary>Assign Role</summary>
+        //                <param name=""role"">Role</param>
+        //                <url>https://localhost/v2/role/{role}/assign</url>
+        //                <verb>put</verb>
+        //                <operationId>AccessControl_AssignRole</operationId>
+        //            </member>
+        //        ");
+
+        //    var openApiPaths = new OpenApiPaths();
+        //    var settings = new PreProcessingOperationFilterSettings();
+
+        //    var filter = new UsePredefinedOperationIdFilter();
+
+        //    // Action
+        //    filter.Apply(openApiPaths, element, settings);
+
+        //    // Assert
+        //    string url = "/v2/role/{role}/assign";
+        //    OperationType operationType = OperationType.Put;
+        //    var expectedOperationId = "AccessControl_AssignRole";
+
+        //    openApiPaths.Should().ContainKey(url);
+        //    openApiPaths[url].Operations.Should().ContainKey(operationType);
+
+        //    openApiPaths[url].Operations[operationType]
+        //        .OperationId.Should().BeEquivalentTo(expectedOperationId);
+        //}
+
+        //[Theory]
+        //[MemberData(nameof(GetTestCasesForApplyShouldUseVerbXmlTagAsOperationType))]
+        //public void ApplyShouldUseVerbXmlTagAsOperationType(
+        //    string testName,
+        //    XElement element,
+        //    string url,
+        //    OperationType expectedOperationType)
+        //{
+        //    _output.WriteLine(testName);
+
+        //    // Prepare
+        //    var openApiPaths = new OpenApiPaths();
+        //    var settings = new PreProcessingOperationFilterSettings();
+
+        //    var filter = new UsePredefinedOperationIdFilter();
+
+        //    // Action
+        //    filter.Apply(openApiPaths, element, settings);
+
+        //    // Assert
+        //    openApiPaths.Should().ContainKey(url);
+        //    openApiPaths[url].Operations.Should().ContainKey(expectedOperationType);
+        //}
+
+        //public static IEnumerable<object[]> GetTestCasesForApplyShouldUseVerbXmlTagAsOperationType()
+        //{
+        //    var operationTypeStringList = new string[]
+        //    {
+        //        "get", "put", "post", "delete", "options", "head", "patch", "trace"
+        //    };
+
+        //    var expectedOperationTypeList = new OperationType[]
+        //    {
+        //        OperationType.Get, OperationType.Put, OperationType.Post, OperationType.Delete,
+        //        OperationType.Options, OperationType.Head, OperationType.Patch, OperationType.Trace
+        //    };
+
+        //    foreach (var value in operationTypeStringList.Zip(expectedOperationTypeList))
+        //    {
+        //        var element = XElement.Parse($@"
+        //            <member>
+        //                <summary>Assign Role</summary>
+        //                <param name=""role"">Role</param>
+        //                <url>https://localhost/v2/role/{{role}}/assign</url>
+        //                <verb>put</verb>
+        //                <operationId>AccessControl_AssignRole</operationId>
+        //            </member>
+        //        ");
+        //    }
+
+        //    yield return new object[]
+        //    {
+        //        "Not applicable if no operationId XML tag is present",
+        //        XElement.Parse(@"
+        //            <member>
+        //                <summary>Assign Role</summary>
+        //                <param name=""role"">Role</param>
+        //            </member>
+        //        "),
+        //        false
+        //    };
+
+        //    yield return new object[]
+        //    {
+        //        "Applicable if one operationId XML tag is present",
+        //        XElement.Parse(@"
+        //            <member>
+        //                <summary>Assign Role</summary>
+        //                <param name=""role"">Role</param>
+        //                <operationId>AccessControl_AssignRole</operationId>
+        //            </member>
+        //        "),
+        //        true
+        //    };
+
+        //    yield return new object[]
+        //    {
+        //        "Applicable if multiple operationId XML tags are present",
+        //        XElement.Parse(@"
+        //            <member>
+        //                <operationId>AssignRole</operationId>
+        //                <summary>Assign Role</summary>
+        //                <param name=""role"">Role</param>
+        //                <operationId>AccessControl_AssignRole</operationId>
+        //            </member>
+        //        "),
+        //        true
+        //    };
+        //}
+        public static IEnumerable<object[]> GetTestCasesForApplyShouldUseTheOperationIdXmlTagAsOperationId()
+        {
+            yield return new object[]
+            {
+                "",
+                XElement.Parse(@"
+                    <member>
+                        <summary>Assign Role</summary>
+                        <param name=""role"">Role</param>
+                    </member>
+                "),
+                false
+            };
+
+            yield return new object[]
+            {
+                "Applicable if one operationId XML tag is present",
+                XElement.Parse(@"
+                    <member>
+                        <summary>Assign Role</summary>
+                        <param name=""role"">Role</param>
+                        <operationId>AccessControl_AssignRole</operationId>
+                    </member>
+                "),
+                true
+            };
+
+            yield return new object[]
+            {
+                "Applicable if multiple operationId XML tags are present",
+                XElement.Parse(@"
+                    <member>
+                        <operationId>AssignRole</operationId>
+                        <summary>Assign Role</summary>
+                        <param name=""role"">Role</param>
+                        <operationId>AccessControl_AssignRole</operationId>
+                    </member>
+                "),
+                true
+            };
+        }
+
+        private static string DefaultGetUrlFunc(XElement e)
+        {
+            return "/default/url";
+        }
+
+        private static OperationType DefaultGetOperationMethodFunc(XElement e)
+        {
+            return OperationType.Post;
+        }
+
+        private static string DefaultGetOperationIdFunc(XElement e)
+        {
+            return "Default_Operation_Id";
+        }
+
+        private static bool DefaultHasOperationIdFunc(XElement e)
+        {
+            return true;
+        }
+    }
+}

--- a/test/Microsoft.OpenApi.CSharpAnnotations.DocumentGeneration.Tests/Microsoft.OpenApi.CSharpAnnotations.DocumentGeneration.Tests.csproj
+++ b/test/Microsoft.OpenApi.CSharpAnnotations.DocumentGeneration.Tests/Microsoft.OpenApi.CSharpAnnotations.DocumentGeneration.Tests.csproj
@@ -20,6 +20,7 @@
         </PackageReference>
         <PackageReference Include="Microsoft.OpenApi" Version="1.1.1" />
         <PackageReference Include="Microsoft.OpenApi.Readers" Version="1.1.1" />
+        <PackageReference Include="Moq" Version="4.13.1" />
         <PackageReference Include="Newtonsoft.Json" Version="12.0.1" />
         <PackageReference Include="SharpYaml" Version="1.6.1">
         </PackageReference>
@@ -42,6 +43,18 @@
         <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
       </None>
       <None Update="DocumentVariantTests\Input\AnnotationWithDuplicatePaths.xml">
+        <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+      </None>
+      <None Update="OpenApiDocumentGeneratorTests\Input\AnnotationPredefinedAndGeneratedOperationId.xml">
+        <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+      </None>
+      <None Update="OpenApiDocumentGeneratorTests\Input\AnnotationPredefinedOperationId.xml">
+        <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+      </None>
+      <None Update="OpenApiDocumentGeneratorTests\Output\AnnotationPredefinedAndGeneratedOperationId.Json">
+        <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+      </None>
+      <None Update="OpenApiDocumentGeneratorTests\Output\AnnotationPredefinedOperationId.Json">
         <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
       </None>
       <None Update="OperationConfigTests\Input\AnnotationWithNoSimpleTypeReferenceInOperation.xml">

--- a/test/Microsoft.OpenApi.CSharpAnnotations.DocumentGeneration.Tests/OpenApiDocumentGeneratorTests/Input/AnnotationPredefinedAndGeneratedOperationId.xml
+++ b/test/Microsoft.OpenApi.CSharpAnnotations.DocumentGeneration.Tests/OpenApiDocumentGeneratorTests/Input/AnnotationPredefinedAndGeneratedOperationId.xml
@@ -1,0 +1,249 @@
+﻿<?xml version="1.0"?>
+<doc>
+  <assembly>
+    <name>Microsoft.OpenApi.CSharpAnnotations.DocumentGeneration.Tests.SampleApis</name>
+  </assembly>
+  <members>
+    <member name="T:Microsoft.OpenApi.CSharpAnnotations.DocumentGeneration.Tests.SampleApis.RouteConfig">
+      <summary>
+        Responsible for route configuration
+      </summary>
+    </member>
+    <member name="M:Microsoft.OpenApi.CSharpAnnotations.DocumentGeneration.Tests.SampleApis.RouteConfig.RegisterRoutes(System.Web.Routing.RouteCollection)">
+      <summary>
+        Registers routes
+      </summary>
+      <param name="routes">Route collection</param>
+    </member>
+    <member name="T:Microsoft.OpenApi.CSharpAnnotations.DocumentGeneration.Tests.SampleApis.WebApiConfig">
+      <summary>
+        Web config.
+      </summary>
+    </member>
+    <member name="M:Microsoft.OpenApi.CSharpAnnotations.DocumentGeneration.Tests.SampleApis.WebApiConfig.Register(System.Web.Http.HttpConfiguration)">
+      <summary>
+        Register the configuration, services, and routes.
+      </summary>
+      <param name="config">HTTP Configuration</param>
+    </member>
+    <member name="T:Microsoft.OpenApi.CSharpAnnotations.DocumentGeneration.Tests.SampleApis.Controllers.SampleControllerV1">
+      <summary>
+        Define V1 operations.
+      </summary>
+    </member>
+    <member name="M:Microsoft.OpenApi.CSharpAnnotations.DocumentGeneration.Tests.SampleApis.Controllers.SampleControllerV1.SampleGet1(System.String,System.Boolean)">
+      <summary>
+        Sample Get 1
+      </summary>
+      <group>Sample V1</group>
+      <verb>GET</verb>
+      <operationId>SampleControllerV1_SampleGet1</operationId>
+      <url>http://localhost:9000/V1/samples/{id}?queryBool={queryBool}</url>
+      <param name="sampleHeaderParam1" cref="T:Microsoft.OpenApi.CSharpAnnotations.DocumentGeneration.Tests.Contracts.SampleObject1" in="header">Header param 1</param>
+      <!-- Header parameter with see tag containing custom type reference -->
+      <param name="sampleHeaderParam2" in="header">
+        <see cref="T:System.Collections.Generic.List`1"/>
+        where T is <see cref="T:Microsoft.OpenApi.CSharpAnnotations.DocumentGeneration.Tests.Contracts.ISampleObject4`2"/>
+        where T1 is <see cref="T:Microsoft.OpenApi.CSharpAnnotations.DocumentGeneration.Tests.Contracts.SampleObject1"/>
+        where T2 is <see cref="T:Microsoft.OpenApi.CSharpAnnotations.DocumentGeneration.Tests.Contracts.SampleObject2"/>Header param 2</param>
+      <!-- ////////////////////////// -->
+      <param name="sampleHeaderParam3" cref="T:System.String" in="header">
+        Header param 3
+      </param>
+      <param name="id" cref="T:System.String" in="path">The object id</param>
+      <param name="queryBool" required="true" cref="T:System.Boolean" in="query">Sample query boolean</param>
+      <response code="200">
+        <!--Response headers-->>
+        <header name="TestHeader" cref="T:System.String"><description>Test Header</description></header>
+        <!--///////////////////////-->>
+        <see cref="T:Microsoft.OpenApi.CSharpAnnotations.DocumentGeneration.Tests.Contracts.SampleObject1"/>Sample object retrieved
+      </response>
+      <response code="400">
+        <see cref="T:System.String"/>Bad request
+      </response>
+      <swagger>Group1</swagger>
+      <swagger>Group2</swagger>
+      <returns>The sample object 1</returns>
+    </member>
+    <member name="M:Microsoft.OpenApi.CSharpAnnotations.DocumentGeneration.Tests.SampleApis.Controllers.SampleControllerV1.SampleGet2">
+      <summary>
+        Sample Get 2
+      </summary>
+      <group>Sample V1</group>
+      <verb>GET</verb>
+      <url>http://localhost:9000/V1/samples</url>
+      <param name="sampleHeaderParam1" cref="T:System.Single" in="header">Header param 1</param>
+      <param name="sampleHeaderParam2" cref="T:System.String" in="header">Header param 2</param>
+      <param name="sampleHeaderParam3" cref="T:System.String" in="header">Header param 3</param>
+      <response code="200">
+        <see cref="T:Microsoft.OpenApi.CSharpAnnotations.DocumentGeneration.Tests.Contracts.SampleObject3"/>Paged Entity contract
+      </response>
+      <response code="400">
+        <see cref="T:System.String"/>Bad request
+      </response>
+      <returns>The sample object 3</returns>
+    </member>
+    <member name="M:Microsoft.OpenApi.CSharpAnnotations.DocumentGeneration.Tests.SampleApis.Controllers.SampleControllerV1.SamplePost(Microsoft.OpenApi.CSharpAnnotations.DocumentGeneration.Tests.Contracts.SampleObject3)">
+      <summary>
+        Sample Post
+      </summary>
+      <group>Sample V1</group>
+      <verb>POST</verb>
+      <url>http://localhost:9000/V1/samples</url>
+      <param name="sampleHeaderParam1" cref="T:System.Single" in="header">Header param 1</param>
+      <param name="sampleHeaderParam2" cref="T:System.String" in="header">Header param 2</param>
+      <param name="sampleHeaderParam3" cref="T:System.String" in="header">Header param 3</param>
+      <param name="sampleObject" in="body">
+        <see cref="T:Microsoft.OpenApi.CSharpAnnotations.DocumentGeneration.Tests.Contracts.SampleObject3"/>Sample object
+      </param>
+      <response code="200">
+        <see cref="T:Microsoft.OpenApi.CSharpAnnotations.DocumentGeneration.Tests.Contracts.SampleObject3"/>Sample object posted
+      </response>
+      <response code="400">
+        <see cref="T:System.String"/>Bad request
+      </response>
+    </member>
+    <member name="M:Microsoft.OpenApi.CSharpAnnotations.DocumentGeneration.Tests.SampleApis.Controllers.SampleControllerV1.SamplePut(System.String,Microsoft.OpenApi.CSharpAnnotations.DocumentGeneration.Tests.Contracts.SampleObject1)">
+      <summary>
+        Sample put
+      </summary>
+      <group>Sample V1</group>
+      <verb>PUT</verb>
+      <operationId>SampleControllerV1_SamplePut</operationId>
+      <url>http://localhost:9000/V1/samples/{id}</url>
+      <param name="sampleHeaderParam1" cref="T:System.Single" in="header">Header param 1</param>
+      <param name="sampleHeaderParam2" cref="T:System.String" in="header">Header param 2</param>
+      <param name="sampleHeaderParam3" cref="T:System.String" in="header">Header param 3</param>
+      <param name="id" cref="T:System.String" in="path">The object id</param>
+      <param name="sampleObject" in="body">
+        <see cref="T:Microsoft.OpenApi.CSharpAnnotations.DocumentGeneration.Tests.Contracts.SampleObject1"/>Sample object
+      </param>
+      <response code="200">
+        <see cref="T:Microsoft.OpenApi.CSharpAnnotations.DocumentGeneration.Tests.Contracts.SampleObject1"/>The sample object updated
+      </response>
+      <response code="400">
+        <see cref="T:System.String"/>Bad request
+      </response>
+      <returns>The sample object 1</returns>
+    </member>
+    <member name="T:Microsoft.OpenApi.CSharpAnnotations.DocumentGeneration.Tests.SampleApis.Controllers.SampleControllerV3">
+      <summary>
+        Defines V3 operations.
+      </summary>
+    </member>
+    <member name="M:Microsoft.OpenApi.CSharpAnnotations.DocumentGeneration.Tests.SampleApis.Controllers.SampleControllerV3.SampleGet1">
+      <summary>
+        Sample get 1
+      </summary>
+      <group>Sample V3</group>
+      <verb>GET</verb>
+      <url>http://localhost:9000/V3/samples/</url>
+      <param name="sampleHeaderParam1" cref="T:System.Single" in="header">Header param 1</param>
+      <param name="sampleHeaderParam2" cref="T:System.String" in="header">Header param 2</param>
+      <param name="sampleHeaderParam3" cref="T:System.String" in="header">Header param 3</param>
+      <response code="200">
+        <see cref="T:System.Collections.Generic.List`1"/>
+        where T is <see cref="T:Microsoft.OpenApi.CSharpAnnotations.DocumentGeneration.Tests.Contracts.ISampleObject4`2"/>
+        where T1 is <see cref="T:Microsoft.OpenApi.CSharpAnnotations.DocumentGeneration.Tests.Contracts.SampleObject1"/>
+        where T2 is <see cref="T:Microsoft.OpenApi.CSharpAnnotations.DocumentGeneration.Tests.Contracts.SampleObject2"/>
+        List of sample objects.
+      </response>
+      <response code="400">
+        <see cref="T:System.String"/>Bad request
+      </response>
+    </member>
+    <member name="M:Microsoft.OpenApi.CSharpAnnotations.DocumentGeneration.Tests.SampleApis.Controllers.SampleControllerV3.SampleGet2(System.String,System.String)">
+      <summary>
+        Sample get 2
+      </summary>
+      <group>Sample V3</group>
+      <verb>GET</verb>
+      <operationId>SampleControllerV3_SampleGet2</operationId>
+      <url>http://localhost:9000/V3/samples/{id}?queryString={queryString}</url>
+      <param name="sampleHeaderParam1" cref="T:System.Single" in="header">Header param 1</param>
+      <param name="sampleHeaderParam2" cref="T:System.String" in="header">Header param 2</param>
+      <param name="sampleHeaderParam3" cref="T:System.String" in="header">Header param 3</param>
+      <param name="id" cref="T:System.String" in="path">The object id</param>
+      <param name="queryString" cref="T:System.String" in="query">The sample query string</param>
+      <response code="200">
+        <see cref="T:Microsoft.OpenApi.CSharpAnnotations.DocumentGeneration.Tests.Contracts.ISampleObject4`2"/>
+        where T1 is <see cref="T:Microsoft.OpenApi.CSharpAnnotations.DocumentGeneration.Tests.Contracts.SampleObject1"/>
+        where T2 is <see cref="T:Microsoft.OpenApi.CSharpAnnotations.DocumentGeneration.Tests.Contracts.SampleObject2"/>
+        List of sample objects.
+      </response>
+      <response code="400">
+        <see cref="T:System.String"/>Bad request
+      </response>
+    </member>
+    <member name="T:Microsoft.OpenApi.CSharpAnnotations.DocumentGeneration.Tests.SampleApis.Controllers.SampleControllerV2">
+      <summary>
+        Defines V2 operations.
+      </summary>
+    </member>
+    <member name="M:Microsoft.OpenApi.CSharpAnnotations.DocumentGeneration.Tests.SampleApis.Controllers.SampleControllerV2.DeleteEntity(System.String)">
+      <summary>
+        Sample delete
+      </summary>
+      <group>Sample V2</group>
+      <verb>DELETE</verb>
+      <operationId>SampleControllerV2_DeleteEntity</operationId>
+      <url>http://localhost:9000/V2/samples/{id}</url>
+      <param name="sampleHeaderParam1" cref="T:System.Single" in="header">Header param 1</param>
+      <param name="sampleHeaderParam2" cref="T:System.String" in="header">Header param 2</param>
+      <param name="sampleHeaderParam3" cref="T:System.String" in="header">Header param 3</param>
+      <param name="id" cref="T:System.String" in="path">The object id</param>
+      <response code="200">
+        <see cref="T:Microsoft.OpenApi.CSharpAnnotations.DocumentGeneration.Tests.Contracts.SampleObject1"/>Sample object deleted
+      </response>
+      <response code="400">
+        <see cref="T:System.String"/>Bad request
+      </response>
+    </member>
+    <member name="M:Microsoft.OpenApi.CSharpAnnotations.DocumentGeneration.Tests.SampleApis.Controllers.SampleControllerV2.SampleGet1">
+      <summary>
+        Sample get 1
+      </summary>
+      <group>Sample V2</group>
+      <verb>GET</verb>
+      <url>http://localhost:9000/V2/samples/</url>
+      <param name="sampleHeaderParam1" cref="T:System.Single" in="header">Header param 1</param>
+      <param name="sampleHeaderParam2" cref="T:System.String" in="header">Header param 2</param>
+      <param name="sampleHeaderParam3" cref="T:System.String" in="header">Header param 3</param>
+      <response code="200">
+        <see cref="T:System.Collections.Generic.List`1"/>where T is <see cref="T:Microsoft.OpenApi.CSharpAnnotations.DocumentGeneration.Tests.Contracts.SampleObject2"/>List of sample objects
+      </response>
+      <response code="400">
+        <see cref="T:System.String"/>Bad request
+      </response>
+    </member>
+    <member name="M:Microsoft.OpenApi.CSharpAnnotations.DocumentGeneration.Tests.SampleApis.Controllers.SampleControllerV2.SampleGet2(System.String,System.String)">
+      <summary>
+        Sample get 2
+      </summary>
+      <group>Sample V2</group>
+      <verb>GET</verb>
+      <url>http://localhost:9000/V2/samples/{id}?queryString={queryString}</url>
+      <param name="sampleHeaderParam1" cref="T:System.Single" in="header">Header param 1</param>
+      <param name="sampleHeaderParam2" cref="T:System.String" in="header">Header param 2</param>
+      <param name="sampleHeaderParam3" cref="T:System.String" in="header">Header param 3</param>
+      <param name="id" cref="T:System.String" in="path">The object id</param>
+      <param name="queryString" cref="T:System.String" in="query">The sample query string</param>
+      <response code="200">
+        <see cref="T:Microsoft.OpenApi.CSharpAnnotations.DocumentGeneration.Tests.Contracts.SampleObject2"/>Sample object retrieved
+      </response>
+      <response code="400">
+        <see cref="T:System.String"/>Bad request
+      </response>
+    </member>
+    <member name="T:Microsoft.OpenApi.CSharpAnnotations.DocumentGeneration.Tests.SampleApis.WebApiApplication">
+      <summary>
+        Web API Application.
+      </summary>
+    </member>
+    <member name="M:Microsoft.OpenApi.CSharpAnnotations.DocumentGeneration.Tests.SampleApis.WebApiApplication.Application_Start">
+      <summary>
+        Start application.
+      </summary>
+    </member>
+  </members>
+</doc>

--- a/test/Microsoft.OpenApi.CSharpAnnotations.DocumentGeneration.Tests/OpenApiDocumentGeneratorTests/Input/AnnotationPredefinedOperationId.xml
+++ b/test/Microsoft.OpenApi.CSharpAnnotations.DocumentGeneration.Tests/OpenApiDocumentGeneratorTests/Input/AnnotationPredefinedOperationId.xml
@@ -1,0 +1,254 @@
+﻿<?xml version="1.0"?>
+<doc>
+  <assembly>
+    <name>Microsoft.OpenApi.CSharpAnnotations.DocumentGeneration.Tests.SampleApis</name>
+  </assembly>
+  <members>
+    <member name="T:Microsoft.OpenApi.CSharpAnnotations.DocumentGeneration.Tests.SampleApis.RouteConfig">
+      <summary>
+        Responsible for route configuration
+      </summary>
+    </member>
+    <member name="M:Microsoft.OpenApi.CSharpAnnotations.DocumentGeneration.Tests.SampleApis.RouteConfig.RegisterRoutes(System.Web.Routing.RouteCollection)">
+      <summary>
+        Registers routes
+      </summary>
+      <param name="routes">Route collection</param>
+    </member>
+    <member name="T:Microsoft.OpenApi.CSharpAnnotations.DocumentGeneration.Tests.SampleApis.WebApiConfig">
+      <summary>
+        Web config.
+      </summary>
+    </member>
+    <member name="M:Microsoft.OpenApi.CSharpAnnotations.DocumentGeneration.Tests.SampleApis.WebApiConfig.Register(System.Web.Http.HttpConfiguration)">
+      <summary>
+        Register the configuration, services, and routes.
+      </summary>
+      <param name="config">HTTP Configuration</param>
+    </member>
+    <member name="T:Microsoft.OpenApi.CSharpAnnotations.DocumentGeneration.Tests.SampleApis.Controllers.SampleControllerV1">
+      <summary>
+        Define V1 operations.
+      </summary>
+    </member>
+    <member name="M:Microsoft.OpenApi.CSharpAnnotations.DocumentGeneration.Tests.SampleApis.Controllers.SampleControllerV1.SampleGet1(System.String,System.Boolean)">
+      <summary>
+        Sample Get 1
+      </summary>
+      <group>Sample V1</group>
+      <verb>GET</verb>
+      <operationId>SampleControllerV1_SampleGet1</operationId>
+      <url>http://localhost:9000/V1/samples/{id}?queryBool={queryBool}</url>
+      <param name="sampleHeaderParam1" cref="T:Microsoft.OpenApi.CSharpAnnotations.DocumentGeneration.Tests.Contracts.SampleObject1" in="header">Header param 1</param>
+      <!-- Header parameter with see tag containing custom type reference -->
+      <param name="sampleHeaderParam2" in="header">
+        <see cref="T:System.Collections.Generic.List`1"/>
+        where T is <see cref="T:Microsoft.OpenApi.CSharpAnnotations.DocumentGeneration.Tests.Contracts.ISampleObject4`2"/>
+        where T1 is <see cref="T:Microsoft.OpenApi.CSharpAnnotations.DocumentGeneration.Tests.Contracts.SampleObject1"/>
+        where T2 is <see cref="T:Microsoft.OpenApi.CSharpAnnotations.DocumentGeneration.Tests.Contracts.SampleObject2"/>Header param 2</param>
+      <!-- ////////////////////////// -->
+      <param name="sampleHeaderParam3" cref="T:System.String" in="header">
+        Header param 3
+      </param>
+      <param name="id" cref="T:System.String" in="path">The object id</param>
+      <param name="queryBool" required="true" cref="T:System.Boolean" in="query">Sample query boolean</param>
+      <response code="200">
+        <!--Response headers-->>
+        <header name="TestHeader" cref="T:System.String"><description>Test Header</description></header>
+        <!--///////////////////////-->>
+        <see cref="T:Microsoft.OpenApi.CSharpAnnotations.DocumentGeneration.Tests.Contracts.SampleObject1"/>Sample object retrieved
+      </response>
+      <response code="400">
+        <see cref="T:System.String"/>Bad request
+      </response>
+      <swagger>Group1</swagger>
+      <swagger>Group2</swagger>
+      <returns>The sample object 1</returns>
+    </member>
+    <member name="M:Microsoft.OpenApi.CSharpAnnotations.DocumentGeneration.Tests.SampleApis.Controllers.SampleControllerV1.SampleGet2">
+      <summary>
+        Sample Get 2
+      </summary>
+      <group>Sample V1</group>
+      <verb>GET</verb>
+      <operationId>SampleControllerV1_SampleGet2</operationId>
+      <url>http://localhost:9000/V1/samples</url>
+      <param name="sampleHeaderParam1" cref="T:System.Single" in="header">Header param 1</param>
+      <param name="sampleHeaderParam2" cref="T:System.String" in="header">Header param 2</param>
+      <param name="sampleHeaderParam3" cref="T:System.String" in="header">Header param 3</param>
+      <response code="200">
+        <see cref="T:Microsoft.OpenApi.CSharpAnnotations.DocumentGeneration.Tests.Contracts.SampleObject3"/>Paged Entity contract
+      </response>
+      <response code="400">
+        <see cref="T:System.String"/>Bad request
+      </response>
+      <returns>The sample object 3</returns>
+    </member>
+    <member name="M:Microsoft.OpenApi.CSharpAnnotations.DocumentGeneration.Tests.SampleApis.Controllers.SampleControllerV1.SamplePost(Microsoft.OpenApi.CSharpAnnotations.DocumentGeneration.Tests.Contracts.SampleObject3)">
+      <summary>
+        Sample Post
+      </summary>
+      <group>Sample V1</group>
+      <verb>POST</verb>
+      <operationId>SampleControllerV1_SamplePost</operationId>
+      <url>http://localhost:9000/V1/samples</url>
+      <param name="sampleHeaderParam1" cref="T:System.Single" in="header">Header param 1</param>
+      <param name="sampleHeaderParam2" cref="T:System.String" in="header">Header param 2</param>
+      <param name="sampleHeaderParam3" cref="T:System.String" in="header">Header param 3</param>
+      <param name="sampleObject" in="body">
+        <see cref="T:Microsoft.OpenApi.CSharpAnnotations.DocumentGeneration.Tests.Contracts.SampleObject3"/>Sample object
+      </param>
+      <response code="200">
+        <see cref="T:Microsoft.OpenApi.CSharpAnnotations.DocumentGeneration.Tests.Contracts.SampleObject3"/>Sample object posted
+      </response>
+      <response code="400">
+        <see cref="T:System.String"/>Bad request
+      </response>
+    </member>
+    <member name="M:Microsoft.OpenApi.CSharpAnnotations.DocumentGeneration.Tests.SampleApis.Controllers.SampleControllerV1.SamplePut(System.String,Microsoft.OpenApi.CSharpAnnotations.DocumentGeneration.Tests.Contracts.SampleObject1)">
+      <summary>
+        Sample put
+      </summary>
+      <group>Sample V1</group>
+      <verb>PUT</verb>
+      <operationId>SampleControllerV1_SamplePut</operationId>
+      <url>http://localhost:9000/V1/samples/{id}</url>
+      <param name="sampleHeaderParam1" cref="T:System.Single" in="header">Header param 1</param>
+      <param name="sampleHeaderParam2" cref="T:System.String" in="header">Header param 2</param>
+      <param name="sampleHeaderParam3" cref="T:System.String" in="header">Header param 3</param>
+      <param name="id" cref="T:System.String" in="path">The object id</param>
+      <param name="sampleObject" in="body">
+        <see cref="T:Microsoft.OpenApi.CSharpAnnotations.DocumentGeneration.Tests.Contracts.SampleObject1"/>Sample object
+      </param>
+      <response code="200">
+        <see cref="T:Microsoft.OpenApi.CSharpAnnotations.DocumentGeneration.Tests.Contracts.SampleObject1"/>The sample object updated
+      </response>
+      <response code="400">
+        <see cref="T:System.String"/>Bad request
+      </response>
+      <returns>The sample object 1</returns>
+    </member>
+    <member name="T:Microsoft.OpenApi.CSharpAnnotations.DocumentGeneration.Tests.SampleApis.Controllers.SampleControllerV3">
+      <summary>
+        Defines V3 operations.
+      </summary>
+    </member>
+    <member name="M:Microsoft.OpenApi.CSharpAnnotations.DocumentGeneration.Tests.SampleApis.Controllers.SampleControllerV3.SampleGet1">
+      <summary>
+        Sample get 1
+      </summary>
+      <group>Sample V3</group>
+      <verb>GET</verb>
+      <operationId>SampleControllerV3_SampleGet1</operationId>
+      <url>http://localhost:9000/V3/samples/</url>
+      <param name="sampleHeaderParam1" cref="T:System.Single" in="header">Header param 1</param>
+      <param name="sampleHeaderParam2" cref="T:System.String" in="header">Header param 2</param>
+      <param name="sampleHeaderParam3" cref="T:System.String" in="header">Header param 3</param>
+      <response code="200">
+        <see cref="T:System.Collections.Generic.List`1"/>
+        where T is <see cref="T:Microsoft.OpenApi.CSharpAnnotations.DocumentGeneration.Tests.Contracts.ISampleObject4`2"/>
+        where T1 is <see cref="T:Microsoft.OpenApi.CSharpAnnotations.DocumentGeneration.Tests.Contracts.SampleObject1"/>
+        where T2 is <see cref="T:Microsoft.OpenApi.CSharpAnnotations.DocumentGeneration.Tests.Contracts.SampleObject2"/>
+        List of sample objects.
+      </response>
+      <response code="400">
+        <see cref="T:System.String"/>Bad request
+      </response>
+    </member>
+    <member name="M:Microsoft.OpenApi.CSharpAnnotations.DocumentGeneration.Tests.SampleApis.Controllers.SampleControllerV3.SampleGet2(System.String,System.String)">
+      <summary>
+        Sample get 2
+      </summary>
+      <group>Sample V3</group>
+      <verb>GET</verb>
+      <operationId>SampleControllerV3_SampleGet2</operationId>
+      <url>http://localhost:9000/V3/samples/{id}?queryString={queryString}</url>
+      <param name="sampleHeaderParam1" cref="T:System.Single" in="header">Header param 1</param>
+      <param name="sampleHeaderParam2" cref="T:System.String" in="header">Header param 2</param>
+      <param name="sampleHeaderParam3" cref="T:System.String" in="header">Header param 3</param>
+      <param name="id" cref="T:System.String" in="path">The object id</param>
+      <param name="queryString" cref="T:System.String" in="query">The sample query string</param>
+      <response code="200">
+        <see cref="T:Microsoft.OpenApi.CSharpAnnotations.DocumentGeneration.Tests.Contracts.ISampleObject4`2"/>
+        where T1 is <see cref="T:Microsoft.OpenApi.CSharpAnnotations.DocumentGeneration.Tests.Contracts.SampleObject1"/>
+        where T2 is <see cref="T:Microsoft.OpenApi.CSharpAnnotations.DocumentGeneration.Tests.Contracts.SampleObject2"/>
+        List of sample objects.
+      </response>
+      <response code="400">
+        <see cref="T:System.String"/>Bad request
+      </response>
+    </member>
+    <member name="T:Microsoft.OpenApi.CSharpAnnotations.DocumentGeneration.Tests.SampleApis.Controllers.SampleControllerV2">
+      <summary>
+        Defines V2 operations.
+      </summary>
+    </member>
+    <member name="M:Microsoft.OpenApi.CSharpAnnotations.DocumentGeneration.Tests.SampleApis.Controllers.SampleControllerV2.DeleteEntity(System.String)">
+      <summary>
+        Sample delete
+      </summary>
+      <group>Sample V2</group>
+      <verb>DELETE</verb>
+      <operationId>SampleControllerV2_DeleteEntity</operationId>
+      <url>http://localhost:9000/V2/samples/{id}</url>
+      <param name="sampleHeaderParam1" cref="T:System.Single" in="header">Header param 1</param>
+      <param name="sampleHeaderParam2" cref="T:System.String" in="header">Header param 2</param>
+      <param name="sampleHeaderParam3" cref="T:System.String" in="header">Header param 3</param>
+      <param name="id" cref="T:System.String" in="path">The object id</param>
+      <response code="200">
+        <see cref="T:Microsoft.OpenApi.CSharpAnnotations.DocumentGeneration.Tests.Contracts.SampleObject1"/>Sample object deleted
+      </response>
+      <response code="400">
+        <see cref="T:System.String"/>Bad request
+      </response>
+    </member>
+    <member name="M:Microsoft.OpenApi.CSharpAnnotations.DocumentGeneration.Tests.SampleApis.Controllers.SampleControllerV2.SampleGet1">
+      <summary>
+        Sample get 1
+      </summary>
+      <group>Sample V2</group>
+      <verb>GET</verb>
+      <operationId>SampleControllerV2_SampleGet1</operationId>
+      <url>http://localhost:9000/V2/samples/</url>
+      <param name="sampleHeaderParam1" cref="T:System.Single" in="header">Header param 1</param>
+      <param name="sampleHeaderParam2" cref="T:System.String" in="header">Header param 2</param>
+      <param name="sampleHeaderParam3" cref="T:System.String" in="header">Header param 3</param>
+      <response code="200">
+        <see cref="T:System.Collections.Generic.List`1"/>where T is <see cref="T:Microsoft.OpenApi.CSharpAnnotations.DocumentGeneration.Tests.Contracts.SampleObject2"/>List of sample objects
+      </response>
+      <response code="400">
+        <see cref="T:System.String"/>Bad request
+      </response>
+    </member>
+    <member name="M:Microsoft.OpenApi.CSharpAnnotations.DocumentGeneration.Tests.SampleApis.Controllers.SampleControllerV2.SampleGet2(System.String,System.String)">
+      <summary>
+        Sample get 2
+      </summary>
+      <group>Sample V2</group>
+      <verb>GET</verb>
+      <operationId>SampleControllerV2_SampleGet2</operationId>
+      <url>http://localhost:9000/V2/samples/{id}?queryString={queryString}</url>
+      <param name="sampleHeaderParam1" cref="T:System.Single" in="header">Header param 1</param>
+      <param name="sampleHeaderParam2" cref="T:System.String" in="header">Header param 2</param>
+      <param name="sampleHeaderParam3" cref="T:System.String" in="header">Header param 3</param>
+      <param name="id" cref="T:System.String" in="path">The object id</param>
+      <param name="queryString" cref="T:System.String" in="query">The sample query string</param>
+      <response code="200">
+        <see cref="T:Microsoft.OpenApi.CSharpAnnotations.DocumentGeneration.Tests.Contracts.SampleObject2"/>Sample object retrieved
+      </response>
+      <response code="400">
+        <see cref="T:System.String"/>Bad request
+      </response>
+    </member>
+    <member name="T:Microsoft.OpenApi.CSharpAnnotations.DocumentGeneration.Tests.SampleApis.WebApiApplication">
+      <summary>
+        Web API Application.
+      </summary>
+    </member>
+    <member name="M:Microsoft.OpenApi.CSharpAnnotations.DocumentGeneration.Tests.SampleApis.WebApiApplication.Application_Start">
+      <summary>
+        Start application.
+      </summary>
+    </member>
+  </members>
+</doc>

--- a/test/Microsoft.OpenApi.CSharpAnnotations.DocumentGeneration.Tests/OpenApiDocumentGeneratorTests/OpenApiDocumentGeneratorTest.cs
+++ b/test/Microsoft.OpenApi.CSharpAnnotations.DocumentGeneration.Tests/OpenApiDocumentGeneratorTests/OpenApiDocumentGeneratorTest.cs
@@ -1094,6 +1094,56 @@ namespace Microsoft.OpenApi.CSharpAnnotations.DocumentGeneration.Tests.OpenApiDo
                     OutputDirectory,
                     "AnnotationWithRuntimeSerialization.Json")
             };
+
+            yield return new object[]
+            {
+                "All operations have predefined operation Id",
+                new List<string>
+                {
+                    Path.Combine(InputDirectory, "AnnotationPredefinedOperationId.xml"),
+                    Path.Combine(InputDirectory,
+                        "Microsoft.OpenApi.CSharpAnnotations.DocumentGeneration.Tests.Contracts.xml")
+                },
+                new List<string>
+                {
+                    Path.Combine(
+                        InputDirectory,
+                        "Microsoft.OpenApi.CSharpAnnotations.DocumentGeneration.Tests.SampleApis.dll"),
+                    Path.Combine(
+                        InputDirectory,
+                        "Microsoft.OpenApi.CSharpAnnotations.DocumentGeneration.Tests.Contracts.dll")
+                },
+                "1.0.0",
+                9,
+                Path.Combine(
+                    OutputDirectory,
+                    "AnnotationPredefinedOperationId.Json")
+            };
+
+            yield return new object[]
+            {
+                "A few operations have predefined operation Id, the others are generated",
+                new List<string>
+                {
+                    Path.Combine(InputDirectory, "AnnotationPredefinedAndGeneratedOperationId.xml"),
+                    Path.Combine(InputDirectory,
+                        "Microsoft.OpenApi.CSharpAnnotations.DocumentGeneration.Tests.Contracts.xml")
+                },
+                new List<string>
+                {
+                    Path.Combine(
+                        InputDirectory,
+                        "Microsoft.OpenApi.CSharpAnnotations.DocumentGeneration.Tests.SampleApis.dll"),
+                    Path.Combine(
+                        InputDirectory,
+                        "Microsoft.OpenApi.CSharpAnnotations.DocumentGeneration.Tests.Contracts.dll")
+                },
+                "1.0.0",
+                9,
+                Path.Combine(
+                    OutputDirectory,
+                    "AnnotationPredefinedAndGeneratedOperationId.Json")
+            };
         }
 
         [Theory]

--- a/test/Microsoft.OpenApi.CSharpAnnotations.DocumentGeneration.Tests/OpenApiDocumentGeneratorTests/Output/AnnotationPredefinedAndGeneratedOperationId.Json
+++ b/test/Microsoft.OpenApi.CSharpAnnotations.DocumentGeneration.Tests/OpenApiDocumentGeneratorTests/Output/AnnotationPredefinedAndGeneratedOperationId.Json
@@ -1,0 +1,758 @@
+{
+  "openapi": "3.0.1",
+  "info": {
+    "title": "Microsoft.OpenApi.CSharpAnnotations.DocumentGeneration.Tests.SampleApis",
+    "version": "1.0.0"
+  },
+  "servers": [
+    {
+      "url": "http://localhost:9000"
+    }
+  ],
+  "paths": {
+    "/V1/samples/{id}": {
+      "get": {
+        "tags": [
+          "Sample V1"
+        ],
+        "summary": "Sample Get 1",
+        "operationId": "SampleControllerV1_SampleGet1",
+        "parameters": [
+          {
+            "name": "sampleHeaderParam1",
+            "in": "header",
+            "description": "Header param 1",
+            "schema": {
+              "$ref": "#/components/schemas/Microsoft.OpenApi.CSharpAnnotations.DocumentGeneration.Tests.Contracts.SampleObject1"
+            }
+          },
+          {
+            "name": "sampleHeaderParam2",
+            "in": "header",
+            "description": "Header param 2",
+            "schema": {
+              "type": "array",
+              "items": {
+                "$ref": "#/components/schemas/Microsoft.OpenApi.CSharpAnnotations.DocumentGeneration.Tests.Contracts.ISampleObject4_Microsoft.OpenApi.CSharpAnnotations.DocumentGeneration.Tests.Contracts.SampleObject1-Microsoft.OpenApi.CSharpAnnotations.DocumentGeneration.Tests.Contracts.SampleObject2_"
+              }
+            }
+          },
+          {
+            "name": "sampleHeaderParam3",
+            "in": "header",
+            "description": "Header param 3",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "id",
+            "in": "path",
+            "description": "The object id",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "queryBool",
+            "in": "query",
+            "description": "Sample query boolean",
+            "required": true,
+            "schema": {
+              "type": "boolean"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Sample object retrieved",
+            "headers": {
+              "TestHeader": {
+                "description": "Test Header",
+                "schema": {
+                  "type": "string"
+                }
+              }
+            },
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Microsoft.OpenApi.CSharpAnnotations.DocumentGeneration.Tests.Contracts.SampleObject1"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad request",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
+          }
+        }
+      },
+      "put": {
+        "tags": [
+          "Sample V1"
+        ],
+        "summary": "Sample put",
+        "operationId": "SampleControllerV1_SamplePut",
+        "parameters": [
+          {
+            "name": "sampleHeaderParam1",
+            "in": "header",
+            "description": "Header param 1",
+            "schema": {
+              "type": "number",
+              "format": "float"
+            }
+          },
+          {
+            "name": "sampleHeaderParam2",
+            "in": "header",
+            "description": "Header param 2",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "sampleHeaderParam3",
+            "in": "header",
+            "description": "Header param 3",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "id",
+            "in": "path",
+            "description": "The object id",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "description": "Sample object",
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/Microsoft.OpenApi.CSharpAnnotations.DocumentGeneration.Tests.Contracts.SampleObject1"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "The sample object updated",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Microsoft.OpenApi.CSharpAnnotations.DocumentGeneration.Tests.Contracts.SampleObject1"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad request",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/V1/samples": {
+      "get": {
+        "tags": [
+          "Sample V1"
+        ],
+        "summary": "Sample Get 2",
+        "operationId": "getV1Samples",
+        "parameters": [
+          {
+            "name": "sampleHeaderParam1",
+            "in": "header",
+            "description": "Header param 1",
+            "schema": {
+              "type": "number",
+              "format": "float"
+            }
+          },
+          {
+            "name": "sampleHeaderParam2",
+            "in": "header",
+            "description": "Header param 2",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "sampleHeaderParam3",
+            "in": "header",
+            "description": "Header param 3",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Paged Entity contract",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Microsoft.OpenApi.CSharpAnnotations.DocumentGeneration.Tests.Contracts.SampleObject3"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad request",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
+          }
+        }
+      },
+      "post": {
+        "tags": [
+          "Sample V1"
+        ],
+        "summary": "Sample Post",
+        "operationId": "postV1Samples",
+        "parameters": [
+          {
+            "name": "sampleHeaderParam1",
+            "in": "header",
+            "description": "Header param 1",
+            "schema": {
+              "type": "number",
+              "format": "float"
+            }
+          },
+          {
+            "name": "sampleHeaderParam2",
+            "in": "header",
+            "description": "Header param 2",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "sampleHeaderParam3",
+            "in": "header",
+            "description": "Header param 3",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "description": "Sample object",
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/Microsoft.OpenApi.CSharpAnnotations.DocumentGeneration.Tests.Contracts.SampleObject3"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "Sample object posted",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Microsoft.OpenApi.CSharpAnnotations.DocumentGeneration.Tests.Contracts.SampleObject3"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad request",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/V3/samples/": {
+      "get": {
+        "tags": [
+          "Sample V3"
+        ],
+        "summary": "Sample get 1",
+        "operationId": "getV3Samples",
+        "parameters": [
+          {
+            "name": "sampleHeaderParam1",
+            "in": "header",
+            "description": "Header param 1",
+            "schema": {
+              "type": "number",
+              "format": "float"
+            }
+          },
+          {
+            "name": "sampleHeaderParam2",
+            "in": "header",
+            "description": "Header param 2",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "sampleHeaderParam3",
+            "in": "header",
+            "description": "Header param 3",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "List of sample objects.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/Microsoft.OpenApi.CSharpAnnotations.DocumentGeneration.Tests.Contracts.ISampleObject4_Microsoft.OpenApi.CSharpAnnotations.DocumentGeneration.Tests.Contracts.SampleObject1-Microsoft.OpenApi.CSharpAnnotations.DocumentGeneration.Tests.Contracts.SampleObject2_"
+                  }
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad request",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/V3/samples/{id}": {
+      "get": {
+        "tags": [
+          "Sample V3"
+        ],
+        "summary": "Sample get 2",
+        "operationId": "SampleControllerV3_SampleGet2",
+        "parameters": [
+          {
+            "name": "sampleHeaderParam1",
+            "in": "header",
+            "description": "Header param 1",
+            "schema": {
+              "type": "number",
+              "format": "float"
+            }
+          },
+          {
+            "name": "sampleHeaderParam2",
+            "in": "header",
+            "description": "Header param 2",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "sampleHeaderParam3",
+            "in": "header",
+            "description": "Header param 3",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "id",
+            "in": "path",
+            "description": "The object id",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "queryString",
+            "in": "query",
+            "description": "The sample query string",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "List of sample objects.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Microsoft.OpenApi.CSharpAnnotations.DocumentGeneration.Tests.Contracts.ISampleObject4_Microsoft.OpenApi.CSharpAnnotations.DocumentGeneration.Tests.Contracts.SampleObject1-Microsoft.OpenApi.CSharpAnnotations.DocumentGeneration.Tests.Contracts.SampleObject2_"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad request",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/V2/samples/{id}": {
+      "delete": {
+        "tags": [
+          "Sample V2"
+        ],
+        "summary": "Sample delete",
+        "operationId": "SampleControllerV2_DeleteEntity",
+        "parameters": [
+          {
+            "name": "sampleHeaderParam1",
+            "in": "header",
+            "description": "Header param 1",
+            "schema": {
+              "type": "number",
+              "format": "float"
+            }
+          },
+          {
+            "name": "sampleHeaderParam2",
+            "in": "header",
+            "description": "Header param 2",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "sampleHeaderParam3",
+            "in": "header",
+            "description": "Header param 3",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "id",
+            "in": "path",
+            "description": "The object id",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Sample object deleted",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Microsoft.OpenApi.CSharpAnnotations.DocumentGeneration.Tests.Contracts.SampleObject1"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad request",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
+          }
+        }
+      },
+      "get": {
+        "tags": [
+          "Sample V2"
+        ],
+        "summary": "Sample get 2",
+        "operationId": "getV2SamplesById",
+        "parameters": [
+          {
+            "name": "sampleHeaderParam1",
+            "in": "header",
+            "description": "Header param 1",
+            "schema": {
+              "type": "number",
+              "format": "float"
+            }
+          },
+          {
+            "name": "sampleHeaderParam2",
+            "in": "header",
+            "description": "Header param 2",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "sampleHeaderParam3",
+            "in": "header",
+            "description": "Header param 3",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "id",
+            "in": "path",
+            "description": "The object id",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "queryString",
+            "in": "query",
+            "description": "The sample query string",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Sample object retrieved",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Microsoft.OpenApi.CSharpAnnotations.DocumentGeneration.Tests.Contracts.SampleObject2"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad request",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/V2/samples/": {
+      "get": {
+        "tags": [
+          "Sample V2"
+        ],
+        "summary": "Sample get 1",
+        "operationId": "getV2Samples",
+        "parameters": [
+          {
+            "name": "sampleHeaderParam1",
+            "in": "header",
+            "description": "Header param 1",
+            "schema": {
+              "type": "number",
+              "format": "float"
+            }
+          },
+          {
+            "name": "sampleHeaderParam2",
+            "in": "header",
+            "description": "Header param 2",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "sampleHeaderParam3",
+            "in": "header",
+            "description": "Header param 3",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "List of sample objects",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/Microsoft.OpenApi.CSharpAnnotations.DocumentGeneration.Tests.Contracts.SampleObject2"
+                  }
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad request",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  },
+  "components": {
+    "schemas": {
+      "Microsoft.OpenApi.CSharpAnnotations.DocumentGeneration.Tests.Contracts.SampleObject1": {
+        "required": [
+          "samplePropertyString3",
+          "samplePropertyString4",
+          "samplePropertyEnum"
+        ],
+        "type": "object",
+        "properties": {
+          "samplePropertyBool": {
+            "type": "boolean",
+            "description": "Gets or sets the sample property bool"
+          },
+          "samplePropertyStringInt": {
+            "type": "integer",
+            "description": "Gets or sets the sample property int",
+            "format": "int32"
+          },
+          "samplePropertyString1": {
+            "type": "string",
+            "description": "Gets or sets the sample property string 1"
+          },
+          "samplePropertyString2": {
+            "type": "string",
+            "description": "Gets or sets the sample property string 2"
+          },
+          "samplePropertyString3": {
+            "type": "string",
+            "description": "Gets or sets the sample property string 3"
+          },
+          "samplePropertyString4": {
+            "type": "string",
+            "description": "Gets or sets the sample property string 4"
+          },
+          "samplePropertyEnum": {
+            "enum": [
+              "SampleEnumValue1",
+              "SampleEnumValue2"
+            ],
+            "type": "string",
+            "description": "Gets or sets the sample property enum"
+          }
+        }
+      },
+      "Microsoft.OpenApi.CSharpAnnotations.DocumentGeneration.Tests.Contracts.ISampleObject4_Microsoft.OpenApi.CSharpAnnotations.DocumentGeneration.Tests.Contracts.SampleObject1-Microsoft.OpenApi.CSharpAnnotations.DocumentGeneration.Tests.Contracts.SampleObject2_": {
+        "required": [
+          "samplePropertyTypeT1",
+          "samplePropertyTypeT2"
+        ],
+        "type": "object",
+        "properties": {
+          "samplePropertyTypeT1": {
+            "$ref": "#/components/schemas/Microsoft.OpenApi.CSharpAnnotations.DocumentGeneration.Tests.Contracts.SampleObject1"
+          },
+          "samplePropertyTypeT2": {
+            "$ref": "#/components/schemas/Microsoft.OpenApi.CSharpAnnotations.DocumentGeneration.Tests.Contracts.SampleObject2"
+          }
+        }
+      },
+      "Microsoft.OpenApi.CSharpAnnotations.DocumentGeneration.Tests.Contracts.SampleObject2": {
+        "required": [
+          "samplePropertyInt",
+          "samplePropertyObjectDictionary",
+          "samplePropertyObjectList"
+        ],
+        "type": "object",
+        "properties": {
+          "samplePropertyEnum": {
+            "enum": [
+              "SampleEnumValue1",
+              "SampleEnumValue2"
+            ],
+            "type": "string",
+            "description": "Gets or sets the sample property enum"
+          },
+          "samplePropertyInt": {
+            "type": "string",
+            "description": "Gets or sets the sample property string 1"
+          },
+          "samplePropertyObjectDictionary": {
+            "type": "object",
+            "additionalProperties": {
+              "$ref": "#/components/schemas/Microsoft.OpenApi.CSharpAnnotations.DocumentGeneration.Tests.Contracts.SampleObject1"
+            },
+            "description": "Gets the sample property object dictionary"
+          },
+          "samplePropertyObjectList": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/Microsoft.OpenApi.CSharpAnnotations.DocumentGeneration.Tests.Contracts.SampleObject1"
+            },
+            "description": "Gets the sample property object list"
+          },
+          "samplePropertyString1": {
+            "type": "string",
+            "description": "Gets or sets the sample property string 1"
+          }
+        }
+      },
+      "Microsoft.OpenApi.CSharpAnnotations.DocumentGeneration.Tests.Contracts.SampleObject3": {
+        "required": [
+          "samplePropertyObject"
+        ],
+        "type": "object",
+        "properties": {
+          "samplePropertyObject": {
+            "$ref": "#/components/schemas/Microsoft.OpenApi.CSharpAnnotations.DocumentGeneration.Tests.Contracts.SampleObject2"
+          },
+          "samplePropertyObjectList": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/Microsoft.OpenApi.CSharpAnnotations.DocumentGeneration.Tests.Contracts.SampleObject1"
+            },
+            "description": "Gets the sample property object list"
+          }
+        }
+      }
+    }
+  }
+}

--- a/test/Microsoft.OpenApi.CSharpAnnotations.DocumentGeneration.Tests/OpenApiDocumentGeneratorTests/Output/AnnotationPredefinedOperationId.Json
+++ b/test/Microsoft.OpenApi.CSharpAnnotations.DocumentGeneration.Tests/OpenApiDocumentGeneratorTests/Output/AnnotationPredefinedOperationId.Json
@@ -1,0 +1,758 @@
+{
+  "openapi": "3.0.1",
+  "info": {
+    "title": "Microsoft.OpenApi.CSharpAnnotations.DocumentGeneration.Tests.SampleApis",
+    "version": "1.0.0"
+  },
+  "servers": [
+    {
+      "url": "http://localhost:9000"
+    }
+  ],
+  "paths": {
+    "/V1/samples/{id}": {
+      "get": {
+        "tags": [
+          "Sample V1"
+        ],
+        "summary": "Sample Get 1",
+        "operationId": "SampleControllerV1_SampleGet1",
+        "parameters": [
+          {
+            "name": "sampleHeaderParam1",
+            "in": "header",
+            "description": "Header param 1",
+            "schema": {
+              "$ref": "#/components/schemas/Microsoft.OpenApi.CSharpAnnotations.DocumentGeneration.Tests.Contracts.SampleObject1"
+            }
+          },
+          {
+            "name": "sampleHeaderParam2",
+            "in": "header",
+            "description": "Header param 2",
+            "schema": {
+              "type": "array",
+              "items": {
+                "$ref": "#/components/schemas/Microsoft.OpenApi.CSharpAnnotations.DocumentGeneration.Tests.Contracts.ISampleObject4_Microsoft.OpenApi.CSharpAnnotations.DocumentGeneration.Tests.Contracts.SampleObject1-Microsoft.OpenApi.CSharpAnnotations.DocumentGeneration.Tests.Contracts.SampleObject2_"
+              }
+            }
+          },
+          {
+            "name": "sampleHeaderParam3",
+            "in": "header",
+            "description": "Header param 3",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "id",
+            "in": "path",
+            "description": "The object id",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "queryBool",
+            "in": "query",
+            "description": "Sample query boolean",
+            "required": true,
+            "schema": {
+              "type": "boolean"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Sample object retrieved",
+            "headers": {
+              "TestHeader": {
+                "description": "Test Header",
+                "schema": {
+                  "type": "string"
+                }
+              }
+            },
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Microsoft.OpenApi.CSharpAnnotations.DocumentGeneration.Tests.Contracts.SampleObject1"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad request",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
+          }
+        }
+      },
+      "put": {
+        "tags": [
+          "Sample V1"
+        ],
+        "summary": "Sample put",
+        "operationId": "SampleControllerV1_SamplePut",
+        "parameters": [
+          {
+            "name": "sampleHeaderParam1",
+            "in": "header",
+            "description": "Header param 1",
+            "schema": {
+              "type": "number",
+              "format": "float"
+            }
+          },
+          {
+            "name": "sampleHeaderParam2",
+            "in": "header",
+            "description": "Header param 2",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "sampleHeaderParam3",
+            "in": "header",
+            "description": "Header param 3",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "id",
+            "in": "path",
+            "description": "The object id",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "description": "Sample object",
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/Microsoft.OpenApi.CSharpAnnotations.DocumentGeneration.Tests.Contracts.SampleObject1"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "The sample object updated",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Microsoft.OpenApi.CSharpAnnotations.DocumentGeneration.Tests.Contracts.SampleObject1"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad request",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/V1/samples": {
+      "get": {
+        "tags": [
+          "Sample V1"
+        ],
+        "summary": "Sample Get 2",
+        "operationId": "SampleControllerV1_SampleGet2",
+        "parameters": [
+          {
+            "name": "sampleHeaderParam1",
+            "in": "header",
+            "description": "Header param 1",
+            "schema": {
+              "type": "number",
+              "format": "float"
+            }
+          },
+          {
+            "name": "sampleHeaderParam2",
+            "in": "header",
+            "description": "Header param 2",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "sampleHeaderParam3",
+            "in": "header",
+            "description": "Header param 3",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Paged Entity contract",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Microsoft.OpenApi.CSharpAnnotations.DocumentGeneration.Tests.Contracts.SampleObject3"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad request",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
+          }
+        }
+      },
+      "post": {
+        "tags": [
+          "Sample V1"
+        ],
+        "summary": "Sample Post",
+        "operationId": "SampleControllerV1_SamplePost",
+        "parameters": [
+          {
+            "name": "sampleHeaderParam1",
+            "in": "header",
+            "description": "Header param 1",
+            "schema": {
+              "type": "number",
+              "format": "float"
+            }
+          },
+          {
+            "name": "sampleHeaderParam2",
+            "in": "header",
+            "description": "Header param 2",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "sampleHeaderParam3",
+            "in": "header",
+            "description": "Header param 3",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "description": "Sample object",
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/Microsoft.OpenApi.CSharpAnnotations.DocumentGeneration.Tests.Contracts.SampleObject3"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "Sample object posted",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Microsoft.OpenApi.CSharpAnnotations.DocumentGeneration.Tests.Contracts.SampleObject3"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad request",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/V3/samples/": {
+      "get": {
+        "tags": [
+          "Sample V3"
+        ],
+        "summary": "Sample get 1",
+        "operationId": "SampleControllerV3_SampleGet1",
+        "parameters": [
+          {
+            "name": "sampleHeaderParam1",
+            "in": "header",
+            "description": "Header param 1",
+            "schema": {
+              "type": "number",
+              "format": "float"
+            }
+          },
+          {
+            "name": "sampleHeaderParam2",
+            "in": "header",
+            "description": "Header param 2",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "sampleHeaderParam3",
+            "in": "header",
+            "description": "Header param 3",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "List of sample objects.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/Microsoft.OpenApi.CSharpAnnotations.DocumentGeneration.Tests.Contracts.ISampleObject4_Microsoft.OpenApi.CSharpAnnotations.DocumentGeneration.Tests.Contracts.SampleObject1-Microsoft.OpenApi.CSharpAnnotations.DocumentGeneration.Tests.Contracts.SampleObject2_"
+                  }
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad request",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/V3/samples/{id}": {
+      "get": {
+        "tags": [
+          "Sample V3"
+        ],
+        "summary": "Sample get 2",
+        "operationId": "SampleControllerV3_SampleGet2",
+        "parameters": [
+          {
+            "name": "sampleHeaderParam1",
+            "in": "header",
+            "description": "Header param 1",
+            "schema": {
+              "type": "number",
+              "format": "float"
+            }
+          },
+          {
+            "name": "sampleHeaderParam2",
+            "in": "header",
+            "description": "Header param 2",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "sampleHeaderParam3",
+            "in": "header",
+            "description": "Header param 3",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "id",
+            "in": "path",
+            "description": "The object id",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "queryString",
+            "in": "query",
+            "description": "The sample query string",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "List of sample objects.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Microsoft.OpenApi.CSharpAnnotations.DocumentGeneration.Tests.Contracts.ISampleObject4_Microsoft.OpenApi.CSharpAnnotations.DocumentGeneration.Tests.Contracts.SampleObject1-Microsoft.OpenApi.CSharpAnnotations.DocumentGeneration.Tests.Contracts.SampleObject2_"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad request",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/V2/samples/{id}": {
+      "delete": {
+        "tags": [
+          "Sample V2"
+        ],
+        "summary": "Sample delete",
+        "operationId": "SampleControllerV2_DeleteEntity",
+        "parameters": [
+          {
+            "name": "sampleHeaderParam1",
+            "in": "header",
+            "description": "Header param 1",
+            "schema": {
+              "type": "number",
+              "format": "float"
+            }
+          },
+          {
+            "name": "sampleHeaderParam2",
+            "in": "header",
+            "description": "Header param 2",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "sampleHeaderParam3",
+            "in": "header",
+            "description": "Header param 3",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "id",
+            "in": "path",
+            "description": "The object id",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Sample object deleted",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Microsoft.OpenApi.CSharpAnnotations.DocumentGeneration.Tests.Contracts.SampleObject1"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad request",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
+          }
+        }
+      },
+      "get": {
+        "tags": [
+          "Sample V2"
+        ],
+        "summary": "Sample get 2",
+        "operationId": "SampleControllerV2_SampleGet2",
+        "parameters": [
+          {
+            "name": "sampleHeaderParam1",
+            "in": "header",
+            "description": "Header param 1",
+            "schema": {
+              "type": "number",
+              "format": "float"
+            }
+          },
+          {
+            "name": "sampleHeaderParam2",
+            "in": "header",
+            "description": "Header param 2",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "sampleHeaderParam3",
+            "in": "header",
+            "description": "Header param 3",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "id",
+            "in": "path",
+            "description": "The object id",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "queryString",
+            "in": "query",
+            "description": "The sample query string",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Sample object retrieved",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Microsoft.OpenApi.CSharpAnnotations.DocumentGeneration.Tests.Contracts.SampleObject2"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad request",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/V2/samples/": {
+      "get": {
+        "tags": [
+          "Sample V2"
+        ],
+        "summary": "Sample get 1",
+        "operationId": "SampleControllerV2_SampleGet1",
+        "parameters": [
+          {
+            "name": "sampleHeaderParam1",
+            "in": "header",
+            "description": "Header param 1",
+            "schema": {
+              "type": "number",
+              "format": "float"
+            }
+          },
+          {
+            "name": "sampleHeaderParam2",
+            "in": "header",
+            "description": "Header param 2",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "sampleHeaderParam3",
+            "in": "header",
+            "description": "Header param 3",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "List of sample objects",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/Microsoft.OpenApi.CSharpAnnotations.DocumentGeneration.Tests.Contracts.SampleObject2"
+                  }
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad request",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  },
+  "components": {
+    "schemas": {
+      "Microsoft.OpenApi.CSharpAnnotations.DocumentGeneration.Tests.Contracts.SampleObject1": {
+        "required": [
+          "samplePropertyString3",
+          "samplePropertyString4",
+          "samplePropertyEnum"
+        ],
+        "type": "object",
+        "properties": {
+          "samplePropertyBool": {
+            "type": "boolean",
+            "description": "Gets or sets the sample property bool"
+          },
+          "samplePropertyStringInt": {
+            "type": "integer",
+            "description": "Gets or sets the sample property int",
+            "format": "int32"
+          },
+          "samplePropertyString1": {
+            "type": "string",
+            "description": "Gets or sets the sample property string 1"
+          },
+          "samplePropertyString2": {
+            "type": "string",
+            "description": "Gets or sets the sample property string 2"
+          },
+          "samplePropertyString3": {
+            "type": "string",
+            "description": "Gets or sets the sample property string 3"
+          },
+          "samplePropertyString4": {
+            "type": "string",
+            "description": "Gets or sets the sample property string 4"
+          },
+          "samplePropertyEnum": {
+            "enum": [
+              "SampleEnumValue1",
+              "SampleEnumValue2"
+            ],
+            "type": "string",
+            "description": "Gets or sets the sample property enum"
+          }
+        }
+      },
+      "Microsoft.OpenApi.CSharpAnnotations.DocumentGeneration.Tests.Contracts.ISampleObject4_Microsoft.OpenApi.CSharpAnnotations.DocumentGeneration.Tests.Contracts.SampleObject1-Microsoft.OpenApi.CSharpAnnotations.DocumentGeneration.Tests.Contracts.SampleObject2_": {
+        "required": [
+          "samplePropertyTypeT1",
+          "samplePropertyTypeT2"
+        ],
+        "type": "object",
+        "properties": {
+          "samplePropertyTypeT1": {
+            "$ref": "#/components/schemas/Microsoft.OpenApi.CSharpAnnotations.DocumentGeneration.Tests.Contracts.SampleObject1"
+          },
+          "samplePropertyTypeT2": {
+            "$ref": "#/components/schemas/Microsoft.OpenApi.CSharpAnnotations.DocumentGeneration.Tests.Contracts.SampleObject2"
+          }
+        }
+      },
+      "Microsoft.OpenApi.CSharpAnnotations.DocumentGeneration.Tests.Contracts.SampleObject2": {
+        "required": [
+          "samplePropertyInt",
+          "samplePropertyObjectDictionary",
+          "samplePropertyObjectList"
+        ],
+        "type": "object",
+        "properties": {
+          "samplePropertyEnum": {
+            "enum": [
+              "SampleEnumValue1",
+              "SampleEnumValue2"
+            ],
+            "type": "string",
+            "description": "Gets or sets the sample property enum"
+          },
+          "samplePropertyInt": {
+            "type": "string",
+            "description": "Gets or sets the sample property string 1"
+          },
+          "samplePropertyObjectDictionary": {
+            "type": "object",
+            "additionalProperties": {
+              "$ref": "#/components/schemas/Microsoft.OpenApi.CSharpAnnotations.DocumentGeneration.Tests.Contracts.SampleObject1"
+            },
+            "description": "Gets the sample property object dictionary"
+          },
+          "samplePropertyObjectList": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/Microsoft.OpenApi.CSharpAnnotations.DocumentGeneration.Tests.Contracts.SampleObject1"
+            },
+            "description": "Gets the sample property object list"
+          },
+          "samplePropertyString1": {
+            "type": "string",
+            "description": "Gets or sets the sample property string 1"
+          }
+        }
+      },
+      "Microsoft.OpenApi.CSharpAnnotations.DocumentGeneration.Tests.Contracts.SampleObject3": {
+        "required": [
+          "samplePropertyObject"
+        ],
+        "type": "object",
+        "properties": {
+          "samplePropertyObject": {
+            "$ref": "#/components/schemas/Microsoft.OpenApi.CSharpAnnotations.DocumentGeneration.Tests.Contracts.SampleObject2"
+          },
+          "samplePropertyObjectList": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/Microsoft.OpenApi.CSharpAnnotations.DocumentGeneration.Tests.Contracts.SampleObject1"
+            },
+            "description": "Gets the sample property object list"
+          }
+        }
+      }
+    }
+  }
+}

--- a/test/Microsoft.OpenApi.CSharpAnnotations.DocumentGeneration.Tests/OperationHandlerTests/OperationHandler_GetUrlTests.cs
+++ b/test/Microsoft.OpenApi.CSharpAnnotations.DocumentGeneration.Tests/OperationHandlerTests/OperationHandler_GetUrlTests.cs
@@ -1,0 +1,113 @@
+﻿// ------------------------------------------------------------
+//  Copyright (c) Microsoft Corporation.  All rights reserved.
+//  Licensed under the MIT License (MIT). See License.txt in the repo root for license information.
+// ------------------------------------------------------------
+
+using System;
+using System.Collections.Generic;
+using System.Net;
+using System.Xml.Linq;
+using FluentAssertions;
+using Microsoft.OpenApi.CSharpAnnotations.DocumentGeneration.Exceptions;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace Microsoft.OpenApi.CSharpAnnotations.DocumentGeneration.Tests.FilterTests
+{
+    [Collection("DefaultSettings")]
+    public class OperationHandler_GetUrlTests
+    {
+        private readonly ITestOutputHelper _output;
+
+        public OperationHandler_GetUrlTests(ITestOutputHelper output)
+        {
+            _output = output;
+        }
+
+        [Theory]
+        [MemberData(nameof(GetTestCasesForGetUrlShouldReturnTheAbsolutePathUsingUrlXmlTag))]
+        public void GetUrlShouldReturnTheAbsolutePathUsingUrlXmlTag(
+            string testName,
+            XElement element,
+            string expectedUrl)
+        {
+            _output.WriteLine(testName);
+
+            // Action
+            var url = OperationHandler.GetUrl(element);
+
+            // Assert
+            url.Should().BeEquivalentTo(expectedUrl);
+        }
+
+        [Fact]
+        public void GetUrlShouldThrowInvalidUrlExceptionByMissingUrlTag()
+        {
+            var element = XElement.Parse($@"
+                <member>
+                    <!--url>Missing tag!</url-->
+                </member>
+            ");
+
+            // Action
+            Action action = () => { OperationHandler.GetUrl(element); };
+
+            // Assert
+            action.Should().ThrowExactly<InvalidUrlException>();
+        }
+
+
+        [Fact]
+        public void GetUrlShouldThrowInvalidUrlExceptionByWrongUrl()
+        {
+            var element = XElement.Parse($@"
+                <member>
+                    <url>This is not a valid url.</url>
+                </member>
+            ");
+
+            // Action
+            Action action = () => { OperationHandler.GetUrl(element); };
+
+            // Assert
+            action.Should().ThrowExactly<InvalidUrlException>();
+        }
+
+        public static IEnumerable<object[]> GetTestCasesForGetUrlShouldReturnTheAbsolutePathUsingUrlXmlTag()
+        {
+            yield return new object[]
+            {
+                "Simple url works",
+                XElement.Parse(@"
+                    <member>
+                        <url>https://localhost/v2/role/{role}/assign</url>
+                    </member>
+                "),
+                "/v2/role/{role}/assign"
+            };
+
+            yield return new object[]
+            {
+                "Complex encoded url works",
+                XElement.Parse($@"
+                    <member>
+                        <url>{WebUtility.UrlEncode("https://localhost/v2/role/{role}/assign?p1=1&p2=2")}</url>
+                    </member>
+                "),
+                "/v2/role/{role}/assign"
+            };
+
+            yield return new object[]
+            {
+                "The first url is considerd",
+                XElement.Parse(@"
+                    <member>
+                        <url>https://localhost/v2/role/{role}/assign</url>
+                        <url>https://localhost/this/url/should/not/be/considered</url>
+                    </member>
+                "),
+                "/v2/role/{role}/assign"
+            };
+        }
+    }
+}

--- a/test/Microsoft.OpenApi.CSharpAnnotations.DocumentGeneration.Tests/OperationHandlerTests/OperationHandler_OperationIdTests.cs
+++ b/test/Microsoft.OpenApi.CSharpAnnotations.DocumentGeneration.Tests/OperationHandlerTests/OperationHandler_OperationIdTests.cs
@@ -1,0 +1,146 @@
+﻿// ------------------------------------------------------------
+//  Copyright (c) Microsoft Corporation.  All rights reserved.
+//  Licensed under the MIT License (MIT). See License.txt in the repo root for license information.
+// ------------------------------------------------------------
+
+using System;
+using System.Collections.Generic;
+using System.Xml.Linq;
+using FluentAssertions;
+using Microsoft.OpenApi.CSharpAnnotations.DocumentGeneration.Exceptions;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace Microsoft.OpenApi.CSharpAnnotations.DocumentGeneration.Tests.FilterTests
+{
+    [Collection("DefaultSettings")]
+    public class OperationHandler_OperationIdTests
+    {
+        private readonly ITestOutputHelper _output;
+
+        public OperationHandler_OperationIdTests(ITestOutputHelper output)
+        {
+            _output = output;
+        }
+
+        [Theory]
+        [MemberData(nameof(GetTestCasesForHasOperationIdShouldReferToTheOperationIdXmlTag))]
+        public void HasOperationIdShouldReferToTheOperationIdXmlTag(
+            string testName,
+            XElement element,
+            bool expectedResult)
+        {
+            _output.WriteLine(testName);
+            
+            // Action
+            var result = OperationHandler.HasOperationId(element);
+
+            // Assert
+            result.Should().Be(expectedResult);
+        }
+
+        [Fact]
+        public void HasOperationIdShouldReturnFalseByNullInput()
+        {
+            // Action
+            var result = OperationHandler.HasOperationId(null);
+
+            // Assert
+            result.Should().BeFalse();
+        }
+
+        [Fact]
+        public void GetOperationIdShouldUseTheOperationIdXmlTagAsOperationId()
+        {
+            // Prepare
+            var element = XElement.Parse(@"
+                    <member>
+                        <operationId>AccessControl_AssignRole</operationId>
+                    </member>
+                ");
+
+            // Action
+            var result = OperationHandler.GetOperationId(element);
+
+            // Assert
+            var expectedOperationId = "AccessControl_AssignRole";
+            result.Should().BeEquivalentTo(expectedOperationId);
+        }
+
+        [Theory]
+        [MemberData(nameof(GetTestCasesForGetOperationIdShouldThrowInvalidOperationIdExceptionByWrongXml))]
+        public void GetOperationIdShouldThrowInvalidOperationIdExceptionByWrongXml(
+            string testName,
+            XElement element)
+        {
+            _output.WriteLine(testName);
+
+            // Action
+            Action action = () => { OperationHandler.GetOperationId(element); };
+
+            // Assert
+            action.Should().ThrowExactly<InvalidOperationIdException>();
+        }
+
+        public static IEnumerable<object[]> GetTestCasesForHasOperationIdShouldReferToTheOperationIdXmlTag()
+        {
+            yield return new object[]
+            {
+                "Return false if no operationId XML tag is present",
+                XElement.Parse(@"
+                    <member>
+                        <!--operationId>Missing tag!</operationId-->
+                    </member>
+                "),
+                false
+            };
+
+            yield return new object[]
+            {
+                "Return true if one operationId XML tag is present",
+                XElement.Parse(@"
+                    <member>
+                        <operationId>AccessControl_AssignRole</operationId>
+                    </member>
+                "),
+                true
+            };
+
+            yield return new object[]
+            {
+                "Return true if multiple operationId XML tags are present",
+                XElement.Parse(@"
+                    <member>
+                        <operationId>AssignRole</operationId>
+                        <operationId>AccessControl_AssignRole</operationId>
+                    </member>
+                "),
+                true
+            };
+        }
+
+        public static IEnumerable<object[]> GetTestCasesForGetOperationIdShouldThrowInvalidOperationIdExceptionByWrongXml()
+        {
+            yield return new object[]
+            {
+                "Missing operationId tag",
+                XElement.Parse(@"
+                    <member>
+                        <!--operationId>Missing operationId tag</operationId-->
+                    </member>
+                ")
+            };
+
+            yield return new object[]
+            {
+                "More than one operationId tag",
+                XElement.Parse(@"
+                    <member>
+                        <operationId>First operation id</operationId>
+                        <operationId>Second operation id</operationId>
+                    </member>
+                ")
+            };
+        }
+    }
+}

--- a/test/Microsoft.OpenApi.CSharpAnnotations.DocumentGeneration.Tests/OperationHandlerTests/OperationHandler_OperationMethodTests.cs
+++ b/test/Microsoft.OpenApi.CSharpAnnotations.DocumentGeneration.Tests/OperationHandlerTests/OperationHandler_OperationMethodTests.cs
@@ -1,0 +1,91 @@
+﻿// ------------------------------------------------------------
+//  Copyright (c) Microsoft Corporation.  All rights reserved.
+//  Licensed under the MIT License (MIT). See License.txt in the repo root for license information.
+// ------------------------------------------------------------
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Xml.Linq;
+using FluentAssertions;
+using Microsoft.OpenApi.CSharpAnnotations.DocumentGeneration.Exceptions;
+using Microsoft.OpenApi.Models;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace Microsoft.OpenApi.CSharpAnnotations.DocumentGeneration.Tests.FilterTests
+{
+    [Collection("DefaultSettings")]
+    public class OperationHandler_OperationMethodTests
+    {
+        private readonly ITestOutputHelper _output;
+
+        public OperationHandler_OperationMethodTests(ITestOutputHelper output)
+        {
+            _output = output;
+        }
+
+        [Theory]
+        [MemberData(nameof(GetTestCasesForGetOperationMethodShouldUseTheVerbXmlTagAsOperationType))]
+        public void GetOperationMethodShouldUseTheVerbXmlTagAsOperationType(
+            string testName,
+            XElement element,
+            OperationType expectedOperationType)
+        {
+            _output.WriteLine(testName);
+
+            // Action
+            var result = OperationHandler.GetOperationMethod(element);
+
+            // Assert
+            result.Should().BeEquivalentTo(expectedOperationType);
+        }
+
+        [Fact]
+        public void GetOperationMethodShouldThrowInvalidVerbExceptionByMissingVerbTag()
+        {
+            var element = XElement.Parse($@"
+                <member>
+                    <!--verb>Missing tag!</verb-->
+                </member>
+            ");
+
+            // Action
+            Action action = () => { OperationHandler.GetOperationMethod(element); };
+
+            // Assert
+            action.Should().ThrowExactly<InvalidVerbException>();
+        }
+
+        public static IEnumerable<object[]> GetTestCasesForGetOperationMethodShouldUseTheVerbXmlTagAsOperationType()
+        {
+            var operationTypeStringList = new string[]
+            {
+                "get", "put", "post", "delete", "options", "head", "patch", "trace"
+            };
+
+            var expectedOperationTypeList = new OperationType[]
+            {
+                    OperationType.Get, OperationType.Put, OperationType.Post, OperationType.Delete,
+                    OperationType.Options, OperationType.Head, OperationType.Patch, OperationType.Trace
+            };
+
+            var operationTypeList = operationTypeStringList.Zip(expectedOperationTypeList, (s, t) => new { Input = s, Exp = t });
+            foreach (var item in operationTypeList)
+            {
+                var element = XElement.Parse($@"
+                    <member>
+                        <verb>{item.Input}</verb>
+                    </member>
+                ");
+
+                yield return new object[]
+                {
+                    "Test for " + item.Input,
+                    element,
+                    item.Exp
+                };
+            }
+        }
+    }
+}


### PR DESCRIPTION
If the operation described in the XML file has an <operationId> tag, it
is used, otherwise (keeping the original behaviour) the id is generated
using the path (<url>) and the operation type (<verb>).

In order to do this, the following changes have been introduced:
+ Add UsePredefinedOperationIdFilter class which creates operations using
<operationId> tag.

+ Add CreateOperationMetaFilter which executes a list of operation creation
filters. The first successful filter is used to generate the operations.
This mechanism is used to support both the predefined and the generated
operation id: first, the predefined operation id based filter is used, and
if it fails, the operation id generation based filter is executed.

+ Add ICreateOperationPreprocessingOperationFilter to support applicable
check in operation create filters in a general way.

+ Extend OperationHandler with GetOperationId function.
+ Slight refactor.
+ Small fix in GetUrl function.
+ Add extensive unit tests

+ Remove duplicated code from BranchOptionalPathParametersFilter and use
OperationHandler existing functionality.