### PR TITLE
Added support for allOf and oneOf

### DIFF
--- a/src/Microsoft.OpenApi.CSharpAnnotations.DocumentGeneration/AssemblyLoader/AssemblyLoader.cs
+++ b/src/Microsoft.OpenApi.CSharpAnnotations.DocumentGeneration/AssemblyLoader/AssemblyLoader.cs
@@ -146,14 +146,14 @@ namespace Microsoft.OpenApi.CSharpAnnotations.DocumentGeneration.AssemblyLoader
         /// <param name="operationElements">The operation xelements.</param>
         /// <param name="propertyElements">The property xelements</param>
         /// <param name="documentVariantElementName">The document variant element name.</param>
-        /// <param name="internalSchemaGenerationSettings"><see cref="InternalSchemaGenerationSettings"/></param>
+        /// <param name="schemaGenerationSettings"><see cref="SchemaGenerationSettings"/></param>
         /// <returns>Serialized <see cref="InternalGenerationContext"/></returns>
         public string BuildInternalGenerationContext(
             IList<string> contractAssembliesPaths,
             IList<string> operationElements,
             IList<string> propertyElements,
             string documentVariantElementName,
-            InternalSchemaGenerationSettings internalSchemaGenerationSettings)
+            SchemaGenerationSettings schemaGenerationSettings)
         {
             var crefSchemaMap = new Dictionary<string, InternalSchemaGenerationInfo>();
 
@@ -174,14 +174,6 @@ namespace Microsoft.OpenApi.CSharpAnnotations.DocumentGeneration.AssemblyLoader
             }
 
             var referenceRegistryMap = new Dictionary<DocumentVariantInfo, SchemaReferenceRegistry>();
-
-            var schemaGenerationSettings = new SchemaGenerationSettings(new DefaultPropertyNameResolver());
-
-            if (internalSchemaGenerationSettings.PropertyNameResolverName ==
-                 typeof(CamelCasePropertyNameResolver).FullName)
-            {
-                schemaGenerationSettings = new SchemaGenerationSettings(new CamelCasePropertyNameResolver());
-            }
 
             var internalGenerationContext = new InternalGenerationContext();
 

--- a/src/Microsoft.OpenApi.CSharpAnnotations.DocumentGeneration/CamelCasePropertyNameResolver.cs
+++ b/src/Microsoft.OpenApi.CSharpAnnotations.DocumentGeneration/CamelCasePropertyNameResolver.cs
@@ -3,6 +3,7 @@
 //  Licensed under the MIT License (MIT). See LICENSE in the repo root for license information.
 // ------------------------------------------------------------
 
+using System;
 using System.Reflection;
 using Microsoft.OpenApi.CSharpAnnotations.DocumentGeneration.Extensions;
 
@@ -11,6 +12,7 @@ namespace Microsoft.OpenApi.CSharpAnnotations.DocumentGeneration
     /// <summary>
     /// Resolves property name by camel casing.
     /// </summary>
+    [Serializable]
     public class CamelCasePropertyNameResolver : DefaultPropertyNameResolver, IPropertyNameResolver
     {
         /// <summary>

--- a/src/Microsoft.OpenApi.CSharpAnnotations.DocumentGeneration/DefaultPropertyNameResolver.cs
+++ b/src/Microsoft.OpenApi.CSharpAnnotations.DocumentGeneration/DefaultPropertyNameResolver.cs
@@ -3,6 +3,7 @@
 //  Licensed under the MIT License (MIT). See License.txt in the repo root for license information.
 // ------------------------------------------------------------
 
+using System;
 using System.Linq;
 using System.Reflection;
 using Microsoft.OpenApi.CSharpAnnotations.DocumentGeneration.ReferenceRegistries;
@@ -12,6 +13,7 @@ namespace Microsoft.OpenApi.CSharpAnnotations.DocumentGeneration
     /// <summary>
     /// Used by <see cref="SchemaReferenceRegistry"/> to resolve property name for a given <see cref="PropertyInfo"/>.
     /// </summary>
+    [Serializable]
     public class DefaultPropertyNameResolver : IPropertyNameResolver
     {
         /// <summary>

--- a/src/Microsoft.OpenApi.CSharpAnnotations.DocumentGeneration/DefaultSchemaIdResolver.cs
+++ b/src/Microsoft.OpenApi.CSharpAnnotations.DocumentGeneration/DefaultSchemaIdResolver.cs
@@ -1,0 +1,23 @@
+﻿using System;
+using Microsoft.OpenApi.CSharpAnnotations.DocumentGeneration.Extensions;
+using Microsoft.OpenApi.CSharpAnnotations.DocumentGeneration.ReferenceRegistries;
+
+namespace Microsoft.OpenApi.CSharpAnnotations.DocumentGeneration
+{
+    /// <summary>
+    /// Used by <see cref="SchemaReferenceRegistry"/> to resolve schema id name for a given <see cref="Type"/>.
+    /// </summary>
+    [Serializable]
+    public class DefaultSchemaIdResolver : ISchemaIdResolver
+    {
+        /// <inheritdoc />
+        public string ResolveSchemaId(Type type)
+        {
+            // Type.ToString() returns full name for non-generic types and
+            // returns a full name without unnecessary assembly information for generic types.
+            var typeName = type.ToString();
+
+            return typeName.SanitizeClassName();
+        }
+    }
+}

--- a/src/Microsoft.OpenApi.CSharpAnnotations.DocumentGeneration/IDiscriminatorResolver.cs
+++ b/src/Microsoft.OpenApi.CSharpAnnotations.DocumentGeneration/IDiscriminatorResolver.cs
@@ -1,0 +1,27 @@
+﻿using System;
+using System.Reflection;
+using Microsoft.OpenApi.CSharpAnnotations.DocumentGeneration.ReferenceRegistries;
+
+namespace Microsoft.OpenApi.CSharpAnnotations.DocumentGeneration
+{
+    /// <summary>
+    /// Utilized by <see cref="SchemaReferenceRegistry"/> to find information about discriminator
+    /// </summary>
+    public interface IDiscriminatorResolver
+    {
+        /// <summary>
+        /// Resolves the discriminator property
+        /// </summary>
+        /// <param name="parentType">The parent type.</param>
+        /// <returns></returns>
+        PropertyInfo ResolveProperty(Type parentType);
+
+        /// <summary>
+        /// Resolves the mapping key.
+        /// </summary>
+        /// <param name="discriminatorProperty">The discriminator property.</param>
+        /// <param name="childType">The child type.</param>
+        /// <returns></returns>
+        string ResolveMappingKey(PropertyInfo discriminatorProperty, Type childType);
+    }
+}

--- a/src/Microsoft.OpenApi.CSharpAnnotations.DocumentGeneration/ISchemaIdResolver.cs
+++ b/src/Microsoft.OpenApi.CSharpAnnotations.DocumentGeneration/ISchemaIdResolver.cs
@@ -1,0 +1,18 @@
+﻿using System;
+using Microsoft.OpenApi.CSharpAnnotations.DocumentGeneration.ReferenceRegistries;
+
+namespace Microsoft.OpenApi.CSharpAnnotations.DocumentGeneration
+{
+    /// <summary>
+    /// Used by <see cref="SchemaReferenceRegistry"/> to resolve schema id name for a given <see cref="Type"/>.
+    /// </summary>
+    public interface ISchemaIdResolver
+    {
+        /// <summary>
+        /// Resolves the schema identifier.
+        /// </summary>
+        /// <param name="type">The type.</param>
+        /// <returns></returns>
+        string ResolveSchemaId(Type type);
+    }
+}

--- a/src/Microsoft.OpenApi.CSharpAnnotations.DocumentGeneration/InternalOpenApiGenerator.cs
+++ b/src/Microsoft.OpenApi.CSharpAnnotations.DocumentGeneration/InternalOpenApiGenerator.cs
@@ -271,14 +271,8 @@ namespace Microsoft.OpenApi.CSharpAnnotations.DocumentGeneration
 
             try
             {
-                var propertyNameResolverTypeName = _openApiDocumentGenerationSettings.SchemaGenerationSettings
-                    .PropertyNameResolver.GetType().FullName;
 
                 var internalGenerationContext = new InternalGenerationContext();
-                var internalSchemaGenerationSettings = new InternalSchemaGenerationSettings()
-                {
-                    PropertyNameResolverName = propertyNameResolverTypeName
-                };
 
                 generationDiagnostic = new GenerationDiagnostic();
                 var documentGenerationDiagnostic = new DocumentGenerationDiagnostic();
@@ -310,7 +304,7 @@ namespace Microsoft.OpenApi.CSharpAnnotations.DocumentGeneration
                     serializedOperationElements,
                     propertyElements.Select(i => i.ToString()).ToList(),
                     documentVariantElementNames.FirstOrDefault(),
-                    internalSchemaGenerationSettings);
+                    _openApiDocumentGenerationSettings.SchemaGenerationSettings);
 
                 internalGenerationContext =
                       (InternalGenerationContext)JsonConvert.DeserializeObject(
@@ -325,7 +319,7 @@ namespace Microsoft.OpenApi.CSharpAnnotations.DocumentGeneration
                         serializedOperationElements,
                         propertyElements.Select(i => i.ToString()).ToList(),
                         documentVariantElementNames.FirstOrDefault(),
-                        internalSchemaGenerationSettings);
+                        _openApiDocumentGenerationSettings.SchemaGenerationSettings);
 
                     internalGenerationContext =
                         (InternalGenerationContext)JsonConvert.DeserializeObject(

--- a/src/Microsoft.OpenApi.CSharpAnnotations.DocumentGeneration/SchemaGenerationSettings.cs
+++ b/src/Microsoft.OpenApi.CSharpAnnotations.DocumentGeneration/SchemaGenerationSettings.cs
@@ -10,21 +10,39 @@ namespace Microsoft.OpenApi.CSharpAnnotations.DocumentGeneration
     /// <summary>
     /// Specifies the settings for schema generation.
     /// </summary>
+    [Serializable]
     public class SchemaGenerationSettings
     {
         /// <summary>
         /// Creates an instance of <see cref="SchemaGenerationSettings"/> class.
         /// </summary>
         /// <param name="propertyNameResolver">The property name resolver.</param>
-        public SchemaGenerationSettings(IPropertyNameResolver propertyNameResolver)
+        /// <param name="schemaIdResolver"></param>
+        public SchemaGenerationSettings(IPropertyNameResolver propertyNameResolver, ISchemaIdResolver schemaIdResolver = null)
         {
             PropertyNameResolver = propertyNameResolver
-                ?? throw new ArgumentNullException(nameof(propertyNameResolver));
+                                   ?? throw new ArgumentNullException(nameof(propertyNameResolver));
+            SchemaIdResolver = schemaIdResolver ?? new DefaultSchemaIdResolver();
         }
 
         /// <summary>
         /// Gets the property name resolver.
         /// </summary>
         public IPropertyNameResolver PropertyNameResolver { get; }
+
+        /// <summary>
+        /// Gets the schema identifier resolver.
+        /// </summary>
+        public ISchemaIdResolver SchemaIdResolver { get; }
+
+        /// <summary>
+        /// Gets or sets a value indicating whether generator should support inheritance, i.e add allOf and oneOf attributes.
+        /// </summary>
+        public bool IncludeInheritanceInformation { get; set; }
+
+        /// <summary>
+        /// Gets or sets the discriminator resolver.
+        /// </summary>
+        public IDiscriminatorResolver DiscriminatorResolver { get; set; }
     }
 }


### PR DESCRIPTION
- added interface to extend logic responsible for getting key (schema id) for a type
- added interface to find discriminator information
- was not sure what was the purpose of internal settings, switched implementation to use schema generation settings class
    - unit tests forced this class and all its properties to be serializable
- added logic to registry to include child-parent class information as allOf, oneOf
