### PR TITLE
Added support for media types in query parameters

### DIFF
--- a/src/Microsoft.OpenApi.CSharpAnnotations.DocumentGeneration/OperationFilters/ParamToParameterFilter.cs
+++ b/src/Microsoft.OpenApi.CSharpAnnotations.DocumentGeneration/OperationFilters/ParamToParameterFilter.cs
@@ -64,6 +64,7 @@ namespace Microsoft.OpenApi.CSharpAnnotations.DocumentGeneration.OperationFilter
                 {
                     var inValue = paramElement.Attribute(KnownXmlStrings.In)?.Value.Trim();
                     var name = paramElement.Attribute(KnownXmlStrings.Name)?.Value.Trim();
+                    var mediaType = paramElement.Attribute(KnownXmlStrings.Type)?.Value ?? "";
 
                     if (settings.RemoveRoslynDuplicateStringFromParamName)
                     {
@@ -145,9 +146,19 @@ namespace Microsoft.OpenApi.CSharpAnnotations.DocumentGeneration.OperationFilter
                         In = parameterLocation,
                         Description = description,
                         Required = parameterLocation == ParameterLocation.Path || Convert.ToBoolean(isRequired),
-                        Schema = schema,
                         Examples = examples.Any() ? examples : null
                     };
+
+                    // If media type is specified add parameter as content for complex serialization
+                    if (!string.IsNullOrEmpty(mediaType)) {
+                        openApiParameter.Content = new Dictionary<string, OpenApiMediaType>
+                        {
+                            [mediaType] = new OpenApiMediaType { Schema = schema }
+                        };
+                    }
+                    else {
+                        openApiParameter.Schema = schema;
+                    }
 
                     operation.Parameters.Add(openApiParameter);
                 }

--- a/test/Microsoft.OpenApi.CSharpAnnotations.DocumentGeneration.Tests.SampleApis/Controllers/SampleV7Controller.cs
+++ b/test/Microsoft.OpenApi.CSharpAnnotations.DocumentGeneration.Tests.SampleApis/Controllers/SampleV7Controller.cs
@@ -1,0 +1,35 @@
+﻿// ------------------------------------------------------------
+//  Copyright (c) Microsoft Corporation.  All rights reserved.
+//  Licensed under the MIT License (MIT). See License.txt in the repo root for license information.
+// ------------------------------------------------------------
+
+using System;
+using System.Threading.Tasks;
+using System.Web.Http;
+using Microsoft.OpenApi.CSharpAnnotations.DocumentGeneration.Tests.Contracts;
+
+namespace Microsoft.OpenApi.CSharpAnnotations.DocumentGeneration.Tests.SampleApis.Controllers
+{
+    /// <summary>
+    /// Sample v7 controller.
+    /// </summary>
+    public class SampleV7Controller : ApiController
+    {
+        /// <summary>
+        /// Sample get 1
+        /// </summary>
+        /// <group>Sample V7</group>
+        /// <verb>GET</verb>
+        /// <url>https://myapi.sample.com/V7/samples/{id}?queryString={queryString}</url>
+        /// <param name="queryString" cref="string" in="query">Query param 1 with no media type</param>
+        /// <param name="sampleObjectInQuery2" cref="SampleObject1" in="query" type="application/json">Query param as application/json content</param>
+        /// <param name="id" cref="string" in="path">The object id</param>
+        /// <response code="200"><see cref="SampleObject1"/>Sample object retrieved</response>
+        /// <response code="400"><see cref="string"/>Bad request</response>
+        [HttpGet]
+        [Route("V7/samples/{id}")]
+        public async Task<SampleObject1> SampleGet1(string id, string queryString = null) {
+            throw new NotImplementedException();
+        }
+    }
+}

--- a/test/Microsoft.OpenApi.CSharpAnnotations.DocumentGeneration.Tests.SampleApis/Microsoft.OpenApi.CSharpAnnotations.DocumentGeneration.Tests.SampleApis.csproj
+++ b/test/Microsoft.OpenApi.CSharpAnnotations.DocumentGeneration.Tests.SampleApis/Microsoft.OpenApi.CSharpAnnotations.DocumentGeneration.Tests.SampleApis.csproj
@@ -118,6 +118,7 @@
     <Compile Include="Controllers\SampleV4Controller.cs" />
     <Compile Include="Controllers\SampleV6Controller.cs" />
     <Compile Include="Controllers\SampleV5Controller.cs" />
+    <Compile Include="Controllers\SampleV7Controller.cs" />
     <Compile Include="Global.asax.cs">
       <DependentUpon>Global.asax</DependentUpon>
     </Compile>

--- a/test/Microsoft.OpenApi.CSharpAnnotations.DocumentGeneration.Tests/Microsoft.OpenApi.CSharpAnnotations.DocumentGeneration.Tests.csproj
+++ b/test/Microsoft.OpenApi.CSharpAnnotations.DocumentGeneration.Tests/Microsoft.OpenApi.CSharpAnnotations.DocumentGeneration.Tests.csproj
@@ -44,6 +44,12 @@
       <None Update="DocumentVariantTests\Input\AnnotationWithDuplicatePaths.xml">
         <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
       </None>
+      <None Update="OpenApiDocumentGeneratorTests\Input\AnnotationInQueryParamMediaType.xml">
+        <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+      </None>
+      <None Update="OpenApiDocumentGeneratorTests\Output\AnnotationInQueryParamMediaType.json">
+        <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+      </None>
       <None Update="OperationConfigTests\Input\AnnotationWithNoSimpleTypeReferenceInOperation.xml">
         <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
       </None>

--- a/test/Microsoft.OpenApi.CSharpAnnotations.DocumentGeneration.Tests/OpenApiDocumentGeneratorTests/Input/AnnotationInQueryParamMediaType.xml
+++ b/test/Microsoft.OpenApi.CSharpAnnotations.DocumentGeneration.Tests/OpenApiDocumentGeneratorTests/Input/AnnotationInQueryParamMediaType.xml
@@ -1,0 +1,89 @@
+﻿<?xml version="1.0"?>
+<doc>
+  <assembly>
+    <name>Microsoft.OpenApi.CSharpAnnotations.DocumentGeneration.Tests.SampleApis</name>
+  </assembly>
+  <members>
+    <member name="T:Microsoft.OpenApi.CSharpAnnotations.DocumentGeneration.Tests.SampleApis.RouteConfig">
+      <summary>
+        Responsible for route configuration
+      </summary>
+    </member>
+    <member name="M:Microsoft.OpenApi.CSharpAnnotations.DocumentGeneration.Tests.SampleApis.RouteConfig.RegisterRoutes(System.Web.Routing.RouteCollection)">
+      <summary>
+        Registers routes
+      </summary>
+      <param name="routes">Route collection</param>
+    </member>
+    <member name="T:Microsoft.OpenApi.CSharpAnnotations.DocumentGeneration.Tests.SampleApis.WebApiConfig">
+      <summary>
+        Web config.
+      </summary>
+      <security type="http" name="http-bearer">
+        <description>Test security</description>
+        <scheme>bearer</scheme>
+        <bearerFormat>JWT</bearerFormat>
+      </security>
+      <security type="oauth2" name="oauth">
+        <description>Test security</description>
+        <flow type="implicit">
+          <authorizationUrl>https://example.com/api/oauth/dialog</authorizationUrl>
+          <refreshUrl>https://example.com/api/oauth/dialog</refreshUrl>
+          <scope name="scope1">
+            <description>Example flow description</description>
+          </scope>
+        </flow>
+      </security>
+      <security type="openIdConnect" name="openIdConnect">
+        <description>Test security</description>
+        <openIdConnectUrl>https://example.com/api/oauth/dialog</openIdConnectUrl>
+        <scope name="scope1">
+          <description>Scope 1 description</description>
+        </scope>
+        <scope name="scope2">
+          <description>Scope 2 description</description>
+        </scope>
+      </security>
+    </member>
+    <member name="M:Microsoft.OpenApi.CSharpAnnotations.DocumentGeneration.Tests.SampleApis.WebApiConfig.Register(System.Web.Http.HttpConfiguration)">
+      <summary>
+        Register the configuration, services, and routes.
+      </summary>
+      <param name="config">HTTP Configuration</param>
+    </member>
+    <member name="T:Microsoft.OpenApi.CSharpAnnotations.DocumentGeneration.Tests.SampleApis.Controllers.SampleV7Controller">
+      <summary>
+        Sample v7 controller.
+      </summary>
+    </member>
+    <member name="M:Microsoft.OpenApi.CSharpAnnotations.DocumentGeneration.Tests.SampleApis.Controllers.SampleV7Controller.SampleGet1(System.String,System.String)">
+      <summary>
+        Sample get 1
+      </summary>
+      <group>Sample V7</group>
+      <verb>GET</verb>
+      <url>https://myapi.sample.com/V7/samples/{id}?queryString={queryString}</url>
+      <param name="queryString" cref="T:System.String" in="query">Query param 1 with no media type</param>
+      <!-- Query parameter with media type -->
+      <param name="sampleObjectInQuery2" cref="T:Microsoft.OpenApi.CSharpAnnotations.DocumentGeneration.Tests.Contracts.SampleObject1" in="query" type="application/json">Query param as application/json content</param>
+      <!-- ////////////////////// -->
+      <param name="id" cref="T:System.String" in="path">The object id</param>
+      <response code="200">
+        <see cref="T:Microsoft.OpenApi.CSharpAnnotations.DocumentGeneration.Tests.Contracts.SampleObject1"/>Sample object retrieved
+      </response>
+      <response code="400">
+        <see cref="T:System.String"/>Bad request
+      </response>
+    </member>
+    <member name="T:Microsoft.OpenApi.CSharpAnnotations.DocumentGeneration.Tests.SampleApis.WebApiApplication">
+      <summary>
+        Web API Application.
+      </summary>
+    </member>
+    <member name="M:Microsoft.OpenApi.CSharpAnnotations.DocumentGeneration.Tests.SampleApis.WebApiApplication.Application_Start">
+      <summary>
+        Start application.
+      </summary>
+    </member>
+  </members>
+</doc>

--- a/test/Microsoft.OpenApi.CSharpAnnotations.DocumentGeneration.Tests/OpenApiDocumentGeneratorTests/OpenApiDocumentGeneratorTest.cs
+++ b/test/Microsoft.OpenApi.CSharpAnnotations.DocumentGeneration.Tests/OpenApiDocumentGeneratorTests/OpenApiDocumentGeneratorTest.cs
@@ -1094,6 +1094,32 @@ namespace Microsoft.OpenApi.CSharpAnnotations.DocumentGeneration.Tests.OpenApiDo
                     OutputDirectory,
                     "AnnotationWithRuntimeSerialization.Json")
             };
+
+            // Valid XML document with object type in param tags and set with media type application/json
+            yield return new object[]
+            {
+                "Object Type in Param Tags",
+                new List<string>
+                {
+                    Path.Combine(InputDirectory, "AnnotationInQueryParamMediaType.xml"),
+                    Path.Combine(InputDirectory,
+                        "Microsoft.OpenApi.CSharpAnnotations.DocumentGeneration.Tests.Contracts.xml")
+                },
+                new List<string>
+                {
+                    Path.Combine(
+                        InputDirectory,
+                        "Microsoft.OpenApi.CSharpAnnotations.DocumentGeneration.Tests.SampleApis.dll"),
+                    Path.Combine(
+                        InputDirectory,
+                        "Microsoft.OpenApi.CSharpAnnotations.DocumentGeneration.Tests.Contracts.dll")
+                },
+                "1.0.0",
+                1,
+                Path.Combine(
+                    OutputDirectory,
+                    "AnnotationInQueryParamMediaType.Json")
+            };
         }
 
         [Theory]

--- a/test/Microsoft.OpenApi.CSharpAnnotations.DocumentGeneration.Tests/OpenApiDocumentGeneratorTests/Output/AnnotationInQueryParamMediaType.json
+++ b/test/Microsoft.OpenApi.CSharpAnnotations.DocumentGeneration.Tests/OpenApiDocumentGeneratorTests/Output/AnnotationInQueryParamMediaType.json
@@ -1,0 +1,161 @@
+{
+  "openapi": "3.0.1",
+  "info": {
+    "title": "Microsoft.OpenApi.CSharpAnnotations.DocumentGeneration.Tests.SampleApis",
+    "version": "1.0.0"
+  },
+  "servers": [
+    {
+      "url": "https://myapi.sample.com"
+    }
+  ],
+  "paths": {
+    "/V7/samples/{id}": {
+      "get": {
+        "tags": [
+          "Sample V7"
+        ],
+        "summary": "Sample get 1",
+        "operationId": "getV7SamplesById",
+        "parameters": [
+          {
+            "name": "queryString",
+            "in": "query",
+            "description": "Query param 1 with no media type",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "sampleObjectInQuery2",
+            "in": "query",
+            "description": "Query param as application/json content",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Microsoft.OpenApi.CSharpAnnotations.DocumentGeneration.Tests.Contracts.SampleObject1"
+                }
+              }
+            }
+          },
+          {
+            "name": "id",
+            "in": "path",
+            "description": "The object id",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Sample object retrieved",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Microsoft.OpenApi.CSharpAnnotations.DocumentGeneration.Tests.Contracts.SampleObject1"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad request",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  },
+  "components": {
+    "schemas": {
+      "Microsoft.OpenApi.CSharpAnnotations.DocumentGeneration.Tests.Contracts.SampleObject1": {
+        "required": [
+          "samplePropertyString3",
+          "samplePropertyString4",
+          "samplePropertyEnum"
+        ],
+        "type": "object",
+        "properties": {
+          "samplePropertyBool": {
+            "type": "boolean",
+            "description": "Gets or sets the sample property bool"
+          },
+          "samplePropertyStringInt": {
+            "type": "integer",
+            "description": "Gets or sets the sample property int",
+            "format": "int32"
+          },
+          "samplePropertyString1": {
+            "type": "string",
+            "description": "Gets or sets the sample property string 1"
+          },
+          "samplePropertyString2": {
+            "type": "string",
+            "description": "Gets or sets the sample property string 2"
+          },
+          "samplePropertyString3": {
+            "type": "string",
+            "description": "Gets or sets the sample property string 3"
+          },
+          "samplePropertyString4": {
+            "type": "string",
+            "description": "Gets or sets the sample property string 4"
+          },
+          "samplePropertyEnum": {
+            "enum": [
+              "SampleEnumValue1",
+              "SampleEnumValue2"
+            ],
+            "type": "string",
+            "description": "Gets or sets the sample property enum"
+          }
+        }
+      }
+    },
+    "securitySchemes": {
+      "http-bearer": {
+        "type": "http",
+        "description": "Test security",
+        "scheme": "bearer",
+        "bearerFormat": "JWT"
+      },
+      "oauth": {
+        "type": "oauth2",
+        "description": "Test security",
+        "flows": {
+          "implicit": {
+            "authorizationUrl": "https://example.com/api/oauth/dialog",
+            "refreshUrl": "https://example.com/api/oauth/dialog",
+            "scopes": {
+              "scope1": "Example flow description"
+            }
+          }
+        }
+      },
+      "openIdConnect": {
+        "type": "openIdConnect",
+        "description": "Test security",
+        "openIdConnectUrl": "https://example.com/api/oauth/dialog"
+      }
+    }
+  },
+  "security": [
+    {
+      "http-bearer": [],
+      "oauth": [
+        "scope1"
+      ],
+      "openIdConnect": [
+        "scope1",
+        "scope2"
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
This project really helped us out generating OpenAPI 3.0 schemas for out .Net Framework WebAPI. 

In out WebAPI some of the controllers have actions that can have complex types in query and we wanted the possibility of describing those parameters as content, instead of schema.

For example:
```json
"parameters": [
    {
      "name": "queryString",
      "in": "query",
      "description": "Query param 1 with no media type",
      "schema": {
        "type": "string"
      }
    },
    {
      "name": "sampleObjectInQuery2",
      "in": "query",
      "description": "Query param as application/json content",
      "content": {
        "application/json": {
          "schema": {
            "$ref": "#/components/schemas/Microsoft.OpenApi.CSharpAnnotations.DocumentGeneration.Tests.Contracts.SampleObject1"
          }
        }
      }
    }
]
```

Changes introduced:

- Query parameters can have type specified (similar to body parameters)
- If no type is specified describes the parameter as schema (maintains the default behaviour)
- Added a new controller to test default and new behaviour
- Added a test in GetTestCasesForValidDocumentationShouldReturnCorrectDocument


